### PR TITLE
Fix call to logger.log

### DIFF
--- a/irods_capability_automated_ingest/utils.py
+++ b/irods_capability_automated_ingest/utils.py
@@ -23,6 +23,6 @@ def retry(logger, func, *args, max_retries=MAX_RETRIES):
         except Exception as err:
             retries += 1
 
-            logger.log('failed', func=func, args=args, err=err, stacktrace=traceback.extract_tb(err.__traceback__))
+            logger.info('Retrying. retries=' + str(retries), max_retries=max_retries, func=func, args=args, err=err, stacktrace=traceback.extract_tb(err.__traceback__))
             time.sleep(1)
     raise RuntimeError("max retries")


### PR DESCRIPTION
There was a call to logger.log in the logging of a retry attempt which was causing errors on retry. It was using the 'failed' key which does not exist in the dict for structlog.