### PR TITLE
Add S3 support

### DIFF
--- a/irods_capability_automated_ingest/flask_app.py
+++ b/irods_capability_automated_ingest/flask_app.py
@@ -30,8 +30,7 @@ def put(job_name, data):
     data2.setdefault("timeout", 3600)
     data2.setdefault("interval", None)
     data2.setdefault("profile", False)
-    data2.setdefault("list_dir", False)
-    data2.setdefault("scan_dir_list", False)
+    data2.setdefault("files_per_task", 50)
     data2["job_name"] = job_name
     data2["config"] = get_config()
 

--- a/irods_capability_automated_ingest/irods_sync.py
+++ b/irods_capability_automated_ingest/irods_sync.py
@@ -67,8 +67,11 @@ def handle_start(args):
     data["synchronous"] = args.synchronous
     data["progress"] = args.progress
     data["profile"] = args.profile
-    data["list_dir"] = args.list_dir
-    data["scan_dir_list"] = args.scan_dir_list
+    data["files_per_task"] = args.files_per_task
+    data["s3_endpoint_domain"] = args.s3_endpoint_domain
+    data["s3_region_name"] = args.s3_region_name
+    data["s3_keypair"] = args.s3_keypair
+    data["s3_proxy_url"] = args.s3_proxy_url
     data["exclude_file_type"] = ex_arg_list
     data['exclude_file_name'] = [ ''.join(r) for r in args.exclude_file_name ]
     data['exclude_directory_name'] = [ ''.join(r) for r in args.exclude_directory_name ]
@@ -112,8 +115,11 @@ def main():
     parser_start.add_argument('--synchronous', action="store_true", default=False, help='synchronous')
     parser_start.add_argument('--progress', action="store_true", default=False, help='progress')
     parser_start.add_argument('--profile', action="store_true", default=False, help='profile')
-    parser_start.add_argument('--list_dir', action="store_true", default=False, help='list dir')
-    parser_start.add_argument('--scan_dir_list', action="store_true", default=False, help='scan dir list')
+    parser_start.add_argument('--files_per_task', action="store", metavar="FILES PER TASK", type=int, default='50', help='number of paths to process in a given task on the queue')
+    parser_start.add_argument('--s3_endpoint_domain', action="store", metavar="S3 ENDPOINT DOMAIN", type=str, default='s3.amazonaws.com', help='s3 endpoint domain (e.g. s3.amazonaws.com)')
+    parser_start.add_argument('--s3_region_name', action="store", metavar="S3 REGION NAME", type=str, default='us-east-1', help='s3 region name')
+    parser_start.add_argument('--s3_keypair', action="store", metavar="S3 KEYPAIR FILE", type=str, default=None, help='s3 keypair file')
+    parser_start.add_argument('--s3_proxy_url', action="store", metavar="S3 PROXY URL", type=str, default=None, help='URL to proxy for S3 access')
     parser_start.add_argument('--exclude_file_type', nargs=1, action="store", default='none', help='types of files to exclude: regular, directory, character, block, socket, pipe, link')
     parser_start.add_argument('--exclude_file_name', type=list, nargs='+', action="store", default='none', help='a list of space-separated python regular expressions defining the file names to exclude such as "(\S+)exclude" "(\S+)\.hidden"')
     parser_start.add_argument('--exclude_directory_name', type=list, nargs='+', action="store", default='none', help='a list of space-separated python regular expressions defining the directory names to exclude such as "(\S+)exclude" "(\S+)\.hidden"')

--- a/irods_capability_automated_ingest/sync_irods.py
+++ b/irods_capability_automated_ingest/sync_irods.py
@@ -1,5 +1,5 @@
 import os
-from os.path import dirname, getsize, getmtime, basename, abspath
+from os.path import dirname, basename
 from irods.session import iRODSSession
 from irods.models import Resource, DataObject, Collection
 from .sync_utils import size, get_redis, call, get_hdlr_mod
@@ -47,7 +47,7 @@ def create_dirs(hdlr_mod, logger, session, meta, **options):
 
                     call(hdlr_mod, "on_coll_create", create_dir, logger, hdlr_mod, logger, session, meta, **options)
     else:
-        raise Exception("create_dirs: relative path")
+        raise Exception("create_dirs: relative path; target:[" + target + ']; path:[' + path + ']')
 
 
 def create_dir(hdlr_mod, logger, session, meta, **options):
@@ -74,10 +74,11 @@ def get_resource_name(hdlr_mod, session, meta, **options):
 def register_file(hdlr_mod, logger, session, meta, **options):
     dest_dataobj_logical_fullpath = meta["target"]
     source_physical_fullpath = meta["path"]
+    b64_path_str = meta.get('b64_path_str')
 
     phypath_to_register_in_catalog = get_target_path(hdlr_mod, session, meta, **options)
     if phypath_to_register_in_catalog is None:
-        if 'unicode_error_filename' in meta:
+        if b64_path_str is not None:
             phypath_to_register_in_catalog = os.path.join(source_physical_fullpath, meta['unicode_error_filename'])
         else:
             phypath_to_register_in_catalog = source_physical_fullpath
@@ -87,24 +88,28 @@ def register_file(hdlr_mod, logger, session, meta, **options):
     if resc_name is not None:
         options["destRescName"] = resc_name
 
-    if 'b64_path_str' in meta:
-        b64str = meta['b64_path_str']
-        b64decoded_utf8_bstr = base64.b64decode(b64str)
-        source_physical_fullpath = b64decoded_utf8_bstr
+    if b64_path_str is not None:
+        source_physical_fullpath = base64.b64decode(b64_path_str)
 
-    size = getsize(source_physical_fullpath)
-    mtime = int(getmtime(source_physical_fullpath))
-    options[kw.DATA_SIZE_KW] = str(size)
-    options[kw.DATA_MODIFY_KW] = str(mtime)
+    options[kw.DATA_SIZE_KW] = str(meta['size'])
+    options[kw.DATA_MODIFY_KW] = str(int(meta['mtime']))
 
     logger.info("registering object " + dest_dataobj_logical_fullpath + ", options = " + str(options))
     session.data_objects.register(phypath_to_register_in_catalog, dest_dataobj_logical_fullpath, **options)
 
     logger.info("succeeded", task="irods_register_file", path = source_physical_fullpath)
 
-    if 'b64_path_str' in meta:
+    if b64_path_str is not None:
         obj = session.data_objects.get(meta['target'])
         obj.metadata.add("irods::automated_ingest::UnicodeEncodeError", meta['b64_path_str'], 'python3.base64.b64encode(full_path_of_source_file)')
+
+    if meta['is_socket']:
+        obj = session.data_objects.get(dest_dataobj_logical_fullpath)
+        obj.metadata.add('socket_target', 'socket', 'automated_ingest')
+    elif meta['is_link']:
+        obj = session.data_objects.get(dest_dataobj_logical_fullpath)
+        link_target = os.path.join(os.path.dirname(source_physical_fullpath), os.readlink(source_physical_fullpath))
+        obj.metadata.add('link_target', link_target, 'automated_ingest')
 
 def upload_file(hdlr_mod, logger, session, meta, **options):
     dest_dataobj_logical_fullpath = meta["target"]
@@ -126,7 +131,6 @@ def no_op(hdlr_mod, logger, session, meta, **options):
 def sync_file(hdlr_mod, logger, session, meta, **options):
     target = meta["target"]
     path = meta["path"]
-    logger.info("ZZZZ - path:" + path)
     logger.info("syncing object " + target + ", options = " + str(options))
 
     resc_name = get_resource_name(hdlr_mod, session, meta, **options)
@@ -162,20 +166,19 @@ def update_metadata(hdlr_mod, logger, session, meta, **options):
     dest_dataobj_logical_fullpath = meta["target"]
     source_physical_fullpath = meta["path"]
     phypath_to_register_in_catalog = get_target_path(hdlr_mod, session, meta, **options)
+    b64_path_str = meta.get('b64_path_str')
     if phypath_to_register_in_catalog is None:
-        if 'unicode_error_filename' in meta:
+        if b64_path_str is not None:
             # Append generated filename to truncated fullpath because it failed to encode
             phypath_to_register_in_catalog = os.path.join(source_physical_fullpath, meta['unicode_error_filename'])
         else:
             phypath_to_register_in_catalog = source_physical_fullpath
 
-    if 'b64_path_str' in meta:
-        b64str = meta['b64_path_str']
-        b64decoded_utf8_bstr = base64.b64decode(b64str)
-        source_physical_fullpath = b64decoded_utf8_bstr
+    if b64_path_str is not None:
+        source_physical_fullpath = base64.b64decode(b64_path_str)
 
-    size = getsize(source_physical_fullpath)
-    mtime = int(getmtime(source_physical_fullpath))
+    size = int(meta['size'])
+    mtime = int(meta['mtime'])
     logger.info("updating object: " + dest_dataobj_logical_fullpath + ", options = " + str(options))
 
     data_obj_info = {"objPath": dest_dataobj_logical_fullpath}
@@ -195,7 +198,7 @@ def update_metadata(hdlr_mod, logger, session, meta, **options):
                     continue
 
     if not found:
-        if 'unicode_error_filename' in meta:
+        if b64_path_str is not None:
             logger.error("updating object: wrong resource or path, dest_dataobj_logical_fullpath = " + dest_dataobj_logical_fullpath + ", phypath_to_register_in_catalog = " + phypath_to_register_in_catalog + ", phypath_to_register_in_catalog = " + phypath_to_register_in_catalog + ", options = " + str(options))
         else:
             logger.error("updating object: wrong resource or path, dest_dataobj_logical_fullpath = " + dest_dataobj_logical_fullpath + ", source_physical_fullpath = " + source_physical_fullpath + ", phypath_to_register_in_catalog = " + phypath_to_register_in_catalog + ", options = " + str(options))
@@ -203,7 +206,7 @@ def update_metadata(hdlr_mod, logger, session, meta, **options):
 
     session.data_objects.modDataObjMeta(data_obj_info, {"dataSize":size, "dataModify":mtime, "allReplStatus":1}, **options)
 
-    if 'unicode_error_filename' in meta:
+    if b64_path_str is not None:
         logger.info("succeeded", task="irods_update_metadata", path = phypath_to_register_in_catalog)
     else:
         logger.info("succeeded", task="irods_update_metadata", path = source_physical_fullpath)
@@ -211,11 +214,6 @@ def update_metadata(hdlr_mod, logger, session, meta, **options):
 
 def sync_file_meta(hdlr_mod, logger, session, meta, **options):
     pass
-
-
-def sync_dir_meta(hdlr_mod, logger, session, meta, **options):
-    pass
-
 
 irods_session_map = {}
 irods_session_timer_map = {}
@@ -330,7 +328,7 @@ def sync_data_from_file(meta, logger, content, **options):
         if session.data_objects.exists(target):
             exists = True
         elif session.collections.exists(target):
-            raise Exception("sync: cannot syncing file " + path + " to collection " + target)
+            raise Exception("sync: cannot sync file " + path + " to collection " + target)
         else:
             exists = False
 
@@ -397,150 +395,3 @@ def sync_data_from_file(meta, logger, content, **options):
 def sync_metadata_from_file(meta, logger, **options):
     sync_data_from_file(meta, logger, False, **options)
 
-
-def sync_data_from_dir(meta, logger, content, **options):
-    target = meta["target"]
-    path = meta["path"]
-    hdlr_mod = get_hdlr_mod(meta)
-
-    session = irods_session(hdlr_mod, meta, logger, **options)
-
-    exists = session.collections.exists(target)
-
-    if hasattr(hdlr_mod, "operation"):
-        op = hdlr_mod.operation(session, meta, **options)
-    else:
-        op = Operation.REGISTER_SYNC
-
-    if op == Operation.NO_OP:
-        if not exists:
-            call(hdlr_mod, "on_coll_create", no_op, logger, hdlr_mod, logger, session, meta, **options)
-        else:
-            call(hdlr_mod, "on_coll_modify", no_op, logger, hdlr_mod, logger, session, meta, **options)
-    else:
-        if not exists:
-            create_dirs(hdlr_mod, logger, session, meta, **options)
-        else:
-            call(hdlr_mod, "on_coll_modify", sync_dir_meta, logger, hdlr_mod, logger, session, meta, **options)
-
-    start_timer()
-
-
-def sync_metadata_from_dir(meta, logger, **options):
-    sync_data_from_dir(meta, logger, False, **options)
-
-def register_link(hdlr_mod, logger, session, meta, **options):
-    target = meta["target"]
-    path = meta["path"]
-    target_path = get_target_path(hdlr_mod, session, meta, **options)
-    if target_path is None:
-        target_path = path
-
-    resc_name = get_resource_name(hdlr_mod, session, meta, **options)
-
-    if resc_name is not None:
-        options["destRescName"] = resc_name
-
-    logger.info("registering link " + target + ", options = " + str(options))
-
-    mtime = int(meta['mtime'])
-
-    data_obj_info = {"objPath": target}
-    if resc_name is not None:
-        del options["destRescName"]
-        for row in session.query(DataObject.replica_number).filter(DataObject.name == basename(target), Collection.name == dirname(target), DataObject.resource_name == resc_name):
-            data_obj_info["replNum"] = int(row[DataObject.replica_number])
-
-    logger.info('PROCESSING: in register_link', task='register_link', path=path)
-    obj = session.data_objects.create(target, resc_name, **options)
-
-    if meta['is_socket']:
-        obj.metadata.add('socket_target', 'socket', 'automated_ingest')
-    elif meta['is_link']:
-        tgt = os.path.abspath(os.readlink(meta['path']))
-        obj.metadata.add('link_target', tgt, 'automated_ingest')
-
-    session.data_objects.modDataObjMeta(data_obj_info, {"dataModify":mtime, "filePath":path}, **options)
-
-    logger.info("succeeded", task="register_link", path = path)
-
-def update_link_metadata(hdlr_mod, logger, session, meta, **options):
-    target = meta["target"]
-    path = meta["path"]
-    target_path = get_target_path(hdlr_mod, session, meta, **options)
-    if target_path is None:
-        target_path = path
-
-    mtime = int(meta['mtime'])
-    logger.info("updating link: " + target + ", options = " + str(options))
-
-    data_obj_info = {"objPath": target}
-
-    resc_name = get_resource_name(hdlr_mod, session, meta, **options)
-    outdated_repl_nums = []
-    found = False
-
-    if resc_name is None:
-        found = True
-    else:
-        for row in session.query(Resource.name, DataObject.path, DataObject.replica_number).filter(DataObject.name == basename(target), Collection.name == dirname(target)):
-            if row[DataObject.path] == path:
-                if child_of(session, row[Resource.name], resc_name):
-                    found = True
-                    repl_num = row[DataObject.replica_number]
-                    data_obj_info["replNum"] = repl_num
-                    continue
-
-    if not found:
-        logger.error("updating object: wrong resource or path, target = " + target + ", path = " + path + ", target_path = " + target_path + ", options = " + str(options))
-        raise Exception("wrong resource or path")
-
-    session.data_objects.modDataObjMeta(data_obj_info, {"dataModify":mtime, "allReplStatus":1}, **options)
-
-    logger.info("succeeded", task="irods_update_link_metadata", path = path)
-
-
-def sync_data_from_link(meta, logger, content, **options):
-    target = meta["target"]
-    path = meta["path"]
-    hdlr_mod = get_hdlr_mod(meta)
-    init = meta["initial_ingest"]
-
-    session = irods_session(hdlr_mod, meta, logger, **options)
-
-    if init:
-        exists = False
-    else:
-        if session.data_objects.exists(target):
-            exists = True
-        elif session.collections.exists(target):
-            raise Exception("sync: cannot syncing link " + path + " to collection " + target)
-        else:
-            exists = False
-
-    if hasattr(hdlr_mod, "operation"):
-        op = hdlr_mod.operation(session, meta, **options)
-    else:
-        op = Operation.REGISTER_SYNC
-
-    if op == Operation.NO_OP:
-        if not exists:
-            call(hdlr_mod, "on_data_obj_create", no_op, logger, hdlr_mod, logger, session, meta, **options)
-        else:
-            call(hdlr_mod, "on_data_obj_modify", no_op, logger, hdlr_mod, logger, session, meta, **options)
-    else:
-        if not exists:
-            meta2 = meta.copy()
-            meta2["target"] = dirname(target)
-            meta2["path"] = dirname(path)
-            create_dirs(hdlr_mod, logger, session, meta2, **options)
-
-            call(hdlr_mod, "on_data_obj_create", register_link, logger, hdlr_mod, logger, session, meta, **options)
-        else:
-            call(hdlr_mod, "on_data_obj_modify", update_link_metadata, logger, hdlr_mod, logger, session, meta, **options)
-
-    start_timer()
-
-
-def sync_metadata_from_link(meta, logger, **options):
-    sync_data_from_link(meta, logger, False, **options)

--- a/irods_capability_automated_ingest/sync_irods.py
+++ b/irods_capability_automated_ingest/sync_irods.py
@@ -368,15 +368,16 @@ def sync_data_from_file(meta, logger, content, **options):
 
         if not exists:
             meta2 = meta.copy()
-            meta2["target"] = dirname(target)
+            if not meta2.get('is_empty_dir'):
+                meta2["target"] = dirname(target)
             if 'b64_path_str' not in meta2:
                 meta2["path"] = dirname(path)
             create_dirs(hdlr_mod, logger, session, meta2, **options)
-
-            if put:
-                call(hdlr_mod, "on_data_obj_create", upload_file, logger, hdlr_mod, logger, session, meta, **options)
-            else:
-                call(hdlr_mod, "on_data_obj_create", register_file, logger, hdlr_mod, logger, session, meta, **options)
+            if not meta2.get('is_empty_dir'):
+                if put:
+                    call(hdlr_mod, "on_data_obj_create", upload_file, logger, hdlr_mod, logger, session, meta, **options)
+                else:
+                    call(hdlr_mod, "on_data_obj_create", register_file, logger, hdlr_mod, logger, session, meta, **options)
         elif createRepl:
             options["regRepl"] = ""
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     keywords='irods automated ingest landingzone filesystem',
     packages=find_packages(),
     install_requires=[
+        'minio',
         'flask',
         'flask-restful',
         'python-irodsclient>=0.8.0',


### PR DESCRIPTION
Adds following command line options to allow for scanning S3 buckets:

- s3_endpoint_domain
- s3_region_name
- s3_keypair
- s3_proxy_url

s3_keypair must point to a file on the local machine with an S3 keypair.
s3_proxy_url is only needed if using a proxy to connect to the S3 endpoint.

S3 buckets are scanned via "chunking" of the retrieved objects such that each task is delegated a chunk of objects, rather than just one. The number of objects to process can be configured with the files_per_task option.

scandir is now the only option for scanning filesystems. As such, list_dir and scan_dir_list command line options have been removed.

Logic for grouping objects to process per task in S3 is now used for filesystem scanner as well. This allows for a significant performance boost to avoid overhead of fetching tasks off the queue for everyfile or object which needs processing.

---
Tests passed (no new tests added). 