### PR TITLE
[#76] Pin redis version to 2.10.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'flask-restful',
         'python-irodsclient>=0.8.0',
         'python-redis-lock>=3.2.0',
-        'redis>=2.10.6',
+        'redis==2.10.6',
         'celery[redis]',
         'scandir',
         'structlog>=18.1.0',


### PR DESCRIPTION
In the future, we should make sure 3.0.x is working and just tie to that version.