### PR TITLE
[#109] Update docker steps for Celery

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,8 @@
 FROM python:3.5
 
-MAINTAINER Hao Xu version: 0.1.0
+RUN pip install irods-capability-automated-ingest
 
-RUN pip install redis==2.10.6 rq==0.10.0 rq-scheduler==0.8.2 python-redis-lock==3.2.0 python-irodsclient==0.8.0
-RUN pip install git+https://github.com/irods/irods_capability_automated_ingest
+COPY irods_environment.json /
 
 ENTRYPOINT ["irods_capability_automated_ingest"]
 CMD ["-h"]

--- a/docker/Dockerfile.ingest_worker
+++ b/docker/Dockerfile.ingest_worker
@@ -1,0 +1,4 @@
+FROM ingest:latest
+
+ENTRYPOINT ["celery", "-A", "irods_capability_automated_ingest.sync_task", "worker", "-Q", "restart,path,file"]
+CMD ["-h"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,54 @@
+# How to dockerize with manual config
+
+An iRODS server is assumed to be running on an accessible network.
+
+## Step 1: Build
+Need a file like this both for the build step and wherever the containers are launched:
+```
+$ cat icommands.env
+IRODS_PORT=1247
+IRODS_HOST=irods-provider
+IRODS_USER_NAME=rods
+IRODS_ZONE_NAME=tempZone
+IRODS_PASSWORD=rods
+```
+This will serve as the iRODS client authentication (rather than running `iinit` somewhere).
+
+Build the ingest image:
+```
+$ docker build -t ingest .
+```
+
+Build the Celery worker image (uses ingest image as a base so as to be identical):
+```
+$ docker build -t ingest-workers -f Dockerfile.ingest_worker .
+```
+
+## Step 2: Start redis server
+
+Start redis server in one container:
+```
+$ docker run --rm --name some-redis -d redis:4.0.8
+```
+
+## Step 3: Start Celery workers
+
+This line will start 4 Celery workers with read-only access to a directory on the host machine:
+```
+docker run --rm --name workers -e "CELERY_BROKER_URL=redis://redis:6379/0" --env-file icommands.env --link some-redis:redis --link irods-provider:icat.example.org -v /path/to/ingest:/mount/path:ro ingest-worker -Q restart,path,file -c 4
+```
+`CELERY_BROKER_URL` is required here in order for the sync tasks to run properly. Replace the URL with the hostname where your redis server is running. `icommands.env` needs to be present somewhere on the machine launching the container in order to authenticate with iRODS server.
+
+The mounted directory path may not need to be read-only depending on your use-case; but, each set of Celery workers must be mounted on the path to scan.
+
+## Step 4: Run an ingest job
+
+Starts a synchronous ingest job with a progress bar:
+```
+docker run --rm -e "CELERY_BROKER_URL=redis://redis:6379/0" --env-file icommands.env --link some-redis:redis --link irods-provider:icat.example.org -v /path/to/ingest:/mount/path:ro ingest start /mount/path /tempZone/home/rods/destination_collection --redis_host redis --synchronous --progress
+```
+
+You can also list, watch, and stop running jobs as per usual by replacing start with whatever you want to run:
+```
+docker run --rm -e "CELERY_BROKER_URL=redis://redis:6379/0" --link some-redis:redis ingest list --redis_host redis
+```

--- a/docker/icommands.env
+++ b/docker/icommands.env
@@ -1,0 +1,7 @@
+IRODS_PORT=1247
+IRODS_HOST=icat.example.org
+IRODS_USER_NAME=rods
+IRODS_ZONE_NAME=tempZone
+IRODS_ENVIRONMENT_FILE=/irods_environment.json
+IRODS_PASSWORD=rods
+

--- a/docker/irods_environment.json
+++ b/docker/irods_environment.json
@@ -1,0 +1,6 @@
+{
+    "irods_host": "icat.example.org",
+    "irods_port": 1247,
+    "irods_user": "rods",
+    "irods_zone_name": "tempZone"
+}


### PR DESCRIPTION
Provides two Dockerfiles:

1. Automated ingest as a python application image

2. Celery worker image based on ingest image

Two additional environment files are required in and
outside of the container to make it run properly:

1. irods_environment.json -- This is not generated,
even with equivalent set of environment variables.

2. icommands.env -- This serves as the authentication
for our iRODS client.