### PR TITLE
[#109] Update docker steps for Celery

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,45 +207,8 @@ python -m irods_capability_automated_ingest.irods_sync watch <job name>
 ```
 
 ### Intermediate: dockerize, manually config (needs to be updated for Celery)
+See [docker/README.md](docker/README.md)
 
-`/tmp/event_handler.py`
-
-```
-from irods_capability_automated_ingest.core import Core
-from irods_capability_automated_ingest.utils import Operation
-
-class event_handler(Core):
-
-    @staticmethod
-    def target_path(session, meta, **options):
-        return "/tmp/host" + path
-
-```
-
-`icommands.env`
-```
-IRODS_PORT=1247
-IRODS_HOST=172.17.0.1
-IRODS_USER_NAME=rods
-IRODS_ZONE_NAME=tempZone
-IRODS_PASSWORD=rods
-```
-
-```
-docker run --rm --name some-redis -d redis:4.0.8
-```
-
-```
-docker run --rm --link some-redis:redis irods_rq-scheduler:0.1.0 worker -u redis://redis:6379/0 restart path file
-```
-
-```
-docker run --rm --link some-redis:redis -v /tmp/host/event_handler.py:/event_handler.py irods_capability_automated_ingest:0.1.0 start /data /tempZone/home/rods/data --redis_host=redis --event_handler=event_handler
-```
-
-```
-docker run --rm --link some-redis:redis --env-file icommands.env -v /tmp/host/data:/data -v /tmp/host/event_handler.py:/event_handler.py irods_rq:0.1.0 worker -u redis://redis:6379/0 restart path file
-```
 ### Advanced: kubernetes (needs to be updated for Celery)
 
 This does not assume that your iRODS installation is in kubernetes.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.5
 
-MAINTAINER Hao Xu version: 0.1.0
+ARG PIP_PACKAGE="irods-capability-automated-ingest"
 
-RUN pip install redis==2.10.6 rq==0.10.0 rq-scheduler==0.8.2 python-redis-lock==3.2.0 python-irodsclient==0.8.0
-RUN pip install git+https://github.com/irods/irods_capability_automated_ingest
+RUN pip install ${PIP_PACKAGE}
+
+COPY irods_environment.json /
 
 ENTRYPOINT ["irods_capability_automated_ingest"]
 CMD ["-h"]

--- a/docker/Dockerfile.ingest_worker
+++ b/docker/Dockerfile.ingest_worker
@@ -1,0 +1,4 @@
+FROM ingest:latest
+
+ENTRYPOINT ["celery", "-A", "irods_capability_automated_ingest.sync_task", "worker", "-Q", "restart,path,file"]
+CMD ["-h"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,54 @@
+# How to dockerize with manual config
+
+An iRODS server is assumed to be running on an accessible network.
+
+## Step 1: Build
+Build the ingest image:
+```
+$ docker build -t ingest .
+```
+
+Build the Celery worker image (uses ingest image as a base so as to be identical):
+```
+$ docker build -t ingest-workers -f Dockerfile.ingest_worker .
+```
+
+## Step 2: Start redis server
+
+Start redis server in one container:
+```
+$ docker run --rm --name some-redis -d redis:4.0.8
+```
+
+## Step 3: Start Celery workers
+Need a file like this from wherever the containers are launched:
+```
+$ cat icommands.env
+IRODS_PORT=1247
+IRODS_HOST=irods-provider
+IRODS_USER_NAME=rods
+IRODS_ZONE_NAME=tempZone
+IRODS_PASSWORD=rods
+```
+This will serve as the iRODS client authentication (rather than running `iinit` somewhere).
+Also need a valid irods_environment.json file.
+
+This line will start 4 Celery workers with read-only access to a directory on the host machine:
+```
+docker run --rm --name workers -e "CELERY_BROKER_URL=redis://redis:6379/0" --env-file icommands.env --link some-redis:redis --link irods-provider:icat.example.org -v /path/to/ingest:/mount/path:ro ingest-worker -c 4
+```
+`CELERY_BROKER_URL` is required here in order for the sync tasks to run properly. Replace the URL with the hostname where your redis server is running. `icommands.env` needs to be present somewhere on the machine launching the container in order to authenticate with iRODS server.
+
+The mounted directory path may not need to be read-only depending on your use-case (i.e. landing zone); but, each set of Celery workers must be mounted on the path to scan.
+
+## Step 4: Run an ingest job
+
+Starts a synchronous ingest job with a progress bar:
+```
+docker run --rm -e "CELERY_BROKER_URL=redis://redis:6379/0" --env-file icommands.env --link some-redis:redis --link irods-provider:icat.example.org -v /path/to/ingest:/mount/path:ro ingest start /mount/path /tempZone/home/rods/destination_collection --synchronous --progress
+```
+
+You can also list, watch, and stop running jobs as per usual by replacing start with whatever you want to run:
+```
+docker run --rm -e "CELERY_BROKER_URL=redis://redis:6379/0" --link some-redis:redis ingest list
+```

--- a/docker/build_images.sh
+++ b/docker/build_images.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+PIP_INSTALL="irods-capability-automated-ingest"
+if [[ ${1} ]]; then
+    PIP_INSTALL=${1}
+fi
+
+BUILD_ARG="PIP_PACKAGE=${PIP_INSTALL}"
+
+docker build --no-cache --build-arg ${BUILD_ARG} -t ingest .
+docker build --no-cache -t ingest-worker -f Dockerfile.ingest_worker .

--- a/docker/icommands.env
+++ b/docker/icommands.env
@@ -1,0 +1,7 @@
+IRODS_PORT=1247
+IRODS_HOST=icat.example.org
+IRODS_USER_NAME=rods
+IRODS_ZONE_NAME=tempZone
+IRODS_ENVIRONMENT_FILE=/irods_environment.json
+IRODS_PASSWORD=rods
+

--- a/docker/irods_environment.json
+++ b/docker/irods_environment.json
@@ -1,0 +1,6 @@
+{
+    "irods_host": "icat.example.org",
+    "irods_port": 1247,
+    "irods_user": "rods",
+    "irods_zone_name": "tempZone"
+}

--- a/docker/launch_worker.sh
+++ b/docker/launch_worker.sh
@@ -1,0 +1,70 @@
+#! /bin/bash
+
+usage() {
+cat <<_EOF_
+Usage: ./launch_worker.sh [OPTIONS]...
+
+Example:
+
+    ./launch_worker.sh --src-dir <arg> --concurrency 4
+
+Stop a running ingest job.
+
+Available options:
+
+    --env-file              Location of file containing iRODS environment variables. 
+    --redis-container       The name of container running redis instance
+    --redis-host            Hostname for redis instance
+    --redis-port            Port for redis instance
+    --redis-db              Database number to be used with redis instance
+    --irods-container       Name of container running iRODS server
+    --irods-host            Hostname for target iRODS server
+    --concurrency           Number of Celery workers to stand up
+    -h, --help              This message
+_EOF_
+    exit
+}
+
+env_file=icommands.env
+irods_host=icat.example.org
+redis_host=redis
+redis_port=6379
+redis_db=0
+concurrency=4
+
+while [ -n "$1" ]; do
+    case "$1" in
+        --redis-container)  shift; redis_container=${1};;
+        --redis-host)       shift; redis_host=${1};;
+        --redis-port)       shift; redis_port=${1};;
+        --redis-db)         shift; redis_db=${1};;
+        --irods-host)       shift; irods_host=${1};;
+        --irods-container)  shift; irods_container=${1};;
+        --src-dir)          shift; src_dir=${1};;
+        --concurrency)      shift; concurrency=${1};;
+        -h|--help)          usage;;
+    esac
+    shift
+done
+
+celery_broker_url="redis://${redis_host}:${redis_port}/${redis_db}"
+
+# Create a makeshift network between the containers, if present
+if [[ ${irods_container} ]]; then
+    container_links="--link ${irods_container}:${irods_host}"
+fi
+
+if [[ ${redis_container} ]]; then
+    container_links="${container_links} --link ${redis_container}:${redis_host}"
+fi
+
+# Uses default values
+docker run \
+    --rm \
+    --name workers \
+    --env-file ${env_file} \
+    -e "CELERY_BROKER_URL=${celery_broker_url}" \
+    ${container_links} \
+    -v ${src_dir}:/data:ro \
+    ingest-worker \
+    -c ${concurrency}

--- a/docker/list_jobs.sh
+++ b/docker/list_jobs.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+usage() {
+cat <<_EOF_
+Usage: ./list_jobs.sh [OPTIONS]...
+
+Lists running ingest jobs.
+
+Available options:
+
+    --redis-container       The name of container running redis instance
+    --redis-host            Hostname for redis instance
+    --redis-port            Port for redis instance
+    --redis-db              Database number to be used with redis instance
+    -h, --help              This message
+_EOF_
+    exit
+}
+
+redis_host=redis
+redis_port=6379
+redis_db=0
+
+while [ -n "$1" ]; do
+    case "$1" in
+        --redis-container)  shift; redis_container=${1};;
+        --redis-host)       shift; redis_host=${1};;
+        --redis-port)       shift; redis_port=${1};;
+        --redis-db)         shift; redis_db=${1};;
+        --ingest-options)   shift; ingest_options=${1};;
+        -h|--help)          usage;;
+    esac
+    shift
+done
+
+celery_broker_url="redis://${redis_host}:${redis_port}/${redis_db}"
+
+if [[ ${redis_container} ]]; then
+    container_links="--link ${redis_container}:${redis_host}"
+fi
+
+docker run \
+    --rm \
+    -e "CELERY_BROKER_URL=${celery_broker_url}" \
+    ${container_links} \
+    ingest \
+    list \
+    ${ingest_options}

--- a/docker/point_and_click.sh
+++ b/docker/point_and_click.sh
@@ -1,0 +1,48 @@
+usage() {
+cat <<_EOF_
+Usage: ./point_and_click.sh [OPTIONS]...
+
+Stand up Celery workers, run an ingest job to completion, and tear down Celery workers.
+
+Available options:
+
+    --env-file              Location of file containing iRODS environment variables. 
+    --redis-container       The name of container running redis instance
+    --irods-container       Name of container running iRODS server
+    --src-dir               Full path to source directory on host machine to be scanned
+    --dest-coll             Full path to desintation iRODS collection
+    -h, --help              This message
+_EOF_
+    exit
+}
+
+while [ -n "$1" ]; do
+    case "$1" in
+        --env-file)              shift; env_file=${1};;
+        --redis-container)       shift; redis_container=${1};;
+        --irods-container)       shift; irods_container=${1};;
+        --src-dir)               shift; src_dir=${1};;
+        --dest-coll)             shift; dest_coll=${1};;
+        -h|--help)               usage;;
+    esac
+    shift
+done
+
+# Create a makeshift network between the containers, if present
+if [[ ${irods_container} ]]; then
+    worker_options="--irods-container ${irods_container}"
+fi
+
+if [[ ${redis_container} ]]; then
+    worker_options="${worker_options} --redis-container ${redis_container}"
+fi
+
+worker_options="${worker_options} --src-dir ${src_dir}"
+
+ingest_options="--synchronous --progress --ignore_cache"
+start_job_options="${worker_options} --dest-coll ${dest_coll} --ingest-options ${ingest_options}"
+
+./launch_worker.sh ${worker_options} &
+./start_job.sh ${start_job_options}
+docker stop workers
+echo $?

--- a/docker/start_job.sh
+++ b/docker/start_job.sh
@@ -1,0 +1,74 @@
+#! /bin/bash
+
+usage() {
+cat <<_EOF_
+Usage: ./start_job.sh [OPTIONS]...
+
+Example:
+
+    ./start_job --src-dir <arg> --dest-coll <arg>
+
+Starts an ingest job targeting the source directory and destination collection.
+
+Available options:
+
+    --env-file              Location of file containing iRODS environment variables. 
+    --redis-container       The name of container running redis instance
+    --redis-host            Hostname for redis instance
+    --redis-port            Port for redis instance
+    --redis-db              Database number to be used with redis instance
+    --irods-host            Hostname for target iRODS server
+    --irods-container       Name of container running iRODS server
+    --src-dir               Full path to source directory on host machine to be scanned
+    --dest-coll             Full path to desintation iRODS collection
+    --ingest-options        Quoted string indicating options to pass to ingest application
+    -h, --help              This message
+_EOF_
+    exit
+}
+
+env_file=icommands.env
+irods_host=icat.example.org
+redis_host=redis
+redis_port=6379
+redis_db=0
+
+while [ -n "$1" ]; do
+    case "$1" in
+        --env-file)              shift; env_file=${1};;
+        --redis-container)       shift; redis_container=${1};;
+        --redis-host)            shift; redis_host=${1};;
+        --redis-port)            shift; redis_port=${1};;
+        --redis-db)              shift; redis_db=${1};;
+        --irods-host)            shift; irods_host=${1};;
+        --irods-container)       shift; irods_container=${1};;
+        --src-dir)               shift; src_dir=${1};;
+        --dest-coll)             shift; dest_coll=${1};;
+        --ingest-options)        shift; ingest_options=${1};;
+        -h|--help)               usage;;
+    esac
+    shift
+done
+
+celery_broker_url="redis://${redis_host}:${redis_port}/${redis_db}"
+
+# Create a makeshift network between the containers, if present
+if [[ ${irods_container} ]]; then
+    container_links="--link ${irods_container}:${irods_host}"
+fi
+
+if [[ ${redis_container} ]]; then
+    container_links="${container_links} --link ${redis_container}:${redis_host}"
+fi
+
+docker run \
+    --rm \
+    --env-file ${env_file} \
+    -e "CELERY_BROKER_URL=${celery_broker_url}" \
+    -v ${src_dir}:/data:ro \
+    ${container_links} \
+    ingest \
+    start \
+    /data \
+    ${dest_coll} \
+    ${ingest_options}

--- a/docker/stop_job.sh
+++ b/docker/stop_job.sh
@@ -1,0 +1,59 @@
+#! /bin/bash
+
+usage() {
+cat <<_EOF_
+Usage: ./stop_job.sh [OPTIONS]...
+
+Example:
+
+    ./stop_job --job-name <arg>
+
+Stop a running ingest job.
+
+Required:
+
+    --job-name              Name of the job to stop (required)
+
+Available options:
+
+    --redis-container       The name of container running redis instance
+    --redis-host            Hostname for redis instance
+    --redis-port            Port for redis instance
+    --redis-db              Database number to be used with redis instance
+    --ingest-options        Quoted string indicating options to pass to ingest application
+    -h, --help              This message
+_EOF_
+    exit
+}
+
+redis_host=redis
+redis_port=6379
+redis_db=0
+
+while [ -n "$1" ]; do
+    case "$1" in
+        --redis-container)  shift; redis_container=${1};;
+        --redis-host)       shift; redis_host=${1};;
+        --redis-port)       shift; redis_port=${1};;
+        --redis-db)         shift; redis_db=${1};;
+        --ingest-options)   shift; ingest_options=${1};;
+        --job-name)         shift; job_name=${1};;
+        -h|--help)          usage;;
+    esac
+    shift
+done
+
+celery_broker_url="redis://${redis_host}:${redis_port}/${redis_db}"
+
+if [[ ${redis_container} ]]; then
+    container_links="--link ${redis_container}:${redis_host}"
+fi
+
+docker run \
+    --rm \
+    -e "CELERY_BROKER_URL=${celery_broker_url}" \
+    ${container_links} \
+    ingest \
+    stop \
+    ${job_name}
+    ${ingest_options}


### PR DESCRIPTION
Provides two Dockerfiles:

1. Automated ingest as a python application image
2. Celery worker image based on ingest image

icommands.env and irods_envirionment.json files are required in and
outside of the container to make it run properly. This serves as the
connection info/authentication for our iRODS client.

Also provides a set of wrapper bash scripts for easy use of the
containers:

1. Scripts for listing, starting, stopping, and watching ingest jobs.
2. "Point-and-click" script: Minimizes typing by standing up Celery
   workers, scanning the target to the destination logical path using
   mainly default settings, and tearing everything down at the end.

NOTE: All of these scripts - especially point_and_click.sh - make a
series of assumptions about where they are running and what is
available to them at runtime. Please do not use these in production.