### PR TITLE
[#114] Remove zone hint check

### DIFF
--- a/irods_capability_automated_ingest/sync_irods.py
+++ b/irods_capability_automated_ingest/sync_irods.py
@@ -2,6 +2,7 @@ import os
 from os.path import dirname, basename
 from irods.session import iRODSSession
 from irods.models import Resource, DataObject, Collection
+from irods.exception import NetworkException
 from .sync_utils import size, get_redis, call, get_hdlr_mod
 from .utils import Operation
 import redis_lock
@@ -16,18 +17,6 @@ def validate_target_collection(meta, logger):
     destination_collection_logical_path = meta["target"]
     if destination_collection_logical_path == "/":
         raise Exception("Root may only contain collections which represent zones")
-
-    # root collection must exist
-    hdlr_mod = get_hdlr_mod(meta)
-    session = irods_session(hdlr_mod, meta, logger)
-    if not session.collections.exists('/'):
-        raise Exception("Root collection does not exist")
-
-    # zone names reside in root in an iRODS logical path and should already exist
-    zone_name = destination_collection_logical_path.strip('/').split('/')[0]
-    logger.info('checking existence of collection for zone:[' + zone_name + ']')
-    if not session.collections.exists('/' + zone_name):
-        raise Exception("Invalid zone name in destination collection path")
 
 def child_of(session, child_resc_name, resc_name):
     if child_resc_name == resc_name:


### PR DESCRIPTION
Zone hint and root collection cannot be seen by rodsusers, so running
ingest as any user other than a rodsadmin currently does not work. The
checks have been removed for now. This is a partial revert of SHA:
ecf5d1e95b9ae41de31c1a6ecd9ecb0bd36b0e3d

Also add NetworkException to sync_irods.