### PR TITLE
[#86][#117] Test suite cleanup + docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,7 @@ celery -A irods_capability_automated_ingest.sync_task worker -l error -Q restart
 **Note:** Make sure queue names match those of the ingest job (default queue names shown here).
 
 #### Run tests
-**Note:** The test suite requires Python version >=3.5.
-**Note:** The tests should be run without running Celery workers.
-```
-python -m irods_capability_automated_ingest.test.test_irods_sync
-```
+See [docker/ingest-test/README.md](docker/ingest-test/README.md) for how to run the test suite.
 
 #### Start sync job
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To scan S3 bucket, minimally requires `--s3_keypair` and source path of the form
 | s3_endpoint_domain | S3 endpoint domain | s3.amazonaws.com |
 | s3_region_name | S3 region name | us-east-1 |
 | s3_proxy_url | URL to proxy for S3 access | None |
+| s3_insecure_connection | Do not use SSL when connecting to S3 endpoint | False |
 
 ### Logging/Profiling options
 | option | effect | default |

--- a/docker/build_images.sh
+++ b/docker/build_images.sh
@@ -7,5 +7,5 @@ fi
 
 BUILD_ARG="PIP_PACKAGE=${PIP_INSTALL}"
 
-docker build --no-cache --build-arg ${BUILD_ARG} -t ingest .
-docker build --no-cache -t ingest-worker -f Dockerfile.ingest_worker .
+docker build --build-arg ${BUILD_ARG} -t ingest .
+docker build -t ingest-worker -f Dockerfile.ingest_worker .

--- a/docker/ingest-test/Dockerfile.test
+++ b/docker/ingest-test/Dockerfile.test
@@ -1,0 +1,5 @@
+FROM ingest:latest
+
+ENV TEST_CASE=${TEST_CASE}
+
+ENTRYPOINT python -m unittest ${TEST_CASE:-irods_capability_automated_ingest.test.test_irods_sync}

--- a/docker/ingest-test/README.md
+++ b/docker/ingest-test/README.md
@@ -1,0 +1,63 @@
+# How to run the test suite using docker
+
+This process is very similar to that of running an ingest job in docker. It is recommended to see [docker/README.md](docker/README.md).
+
+The ingest-test image is based on the ingest docker image found in the docker directory. As such, many of the same requirements hold when running the tests as when a normal ingest job takes place.
+
+## Step 0: Preparing the ground
+An iRODS server is assumed to be running on an accessible network with hostname `icat.example.org` listening on port 1247 (default values).
+The iRODS server is ssumed to have a rodsadmin user named `rods` with password `rods` on zone `tempZone` (default values).
+
+A Redis server is assumed to be running on an accessible network with hostname `redis` listening on port 6379 with an unused database 0 (default values).
+The test suite starts and stops its own workers, so it is advisable to stop any workers pointed at the Redis server you plan to use, or use a different database.
+
+If you don't want to run the tests in a distributed fashion, give `localhost` the needed aliases to refer to the Redis and iRODS servers.
+
+## Step 1: Build Docker images
+Build the ingest image:
+```
+$ docker build -t ingest ..
+```
+
+If you would like to install with a git repo, you can provide a pip-style Git URL to the `PIP_PACKAGE` build argument (e.g.):
+```
+docker build -t ingest --build-arg "PIP_PACKAGE=git+https://github.com/irods/irods_capability_automated_ingest@master"
+```
+
+Build the ingest-test image (uses ingest image as a base so as to be identical):
+```
+$ docker build -t ingest-test -f Dockerfile.test .
+```
+
+## Step 2: Run the tests:
+Need a file like this from wherever the tests are launched:
+```
+$ cat icommands.env
+IRODS_PORT=1247
+IRODS_HOST=icat.example.org
+IRODS_USER_NAME=rods
+IRODS_ZONE_NAME=tempZone
+IRODS_PASSWORD=rods
+```
+This will serve as the iRODS client authentication (rather than running `iinit` somewhere).
+Also need a valid irods_environment.json file.
+
+The default values used by the tests for iRODS interactions are as shown above and should not be changed.
+This is not built into the image because flexibility for server and user information will be provided in the future.
+
+To run the full test suite, run this:
+```
+docker run --rm --env-file icommands.env -v /path/to/mountdir:/tmp/testdir ingest-test
+```
+`/path/to/mountdir` must be accessible to both the ingest-test container and `icat.example.org`. `/tmp/testdir` is hard-coded in the tests - do not change this.
+
+To run a specfic test, set the `TEST_CASE` environment variable to the desired test (dot-notated) when running the container (e.g.):
+```
+docker run --rm --env-file icommands.env -v /path/to/mountdir:/tmp/testdir -e TEST_CASE=test_irods_sync.Test_register.test_register ingest-test
+```
+
+The provided `run_tests.sh` script is a wrapper around the `docker run` commands to help with running the tests.
+This example usage shows running a specific test with local iRODS and Redis containers which will be linked to the container running the tests:
+```
+run_tests.sh --redis-container some-redis --irods-container irods-box --host-mount-dir /path/to/mountdir --specific-test Test_irods_sync_UnicodeEncodeError.test_register
+```

--- a/docker/ingest-test/icommands.env
+++ b/docker/ingest-test/icommands.env
@@ -1,0 +1,7 @@
+IRODS_PORT=1247
+IRODS_HOST=icat.example.org
+IRODS_USER_NAME=rods
+IRODS_ZONE_NAME=tempZone
+IRODS_ENVIRONMENT_FILE=/irods_environment.json
+IRODS_PASSWORD=rods
+

--- a/docker/ingest-test/irods_environment.json
+++ b/docker/ingest-test/irods_environment.json
@@ -1,0 +1,6 @@
+{
+    "irods_host": "icat.example.org",
+    "irods_port": 1247,
+    "irods_user": "rods",
+    "irods_zone_name": "tempZone"
+}

--- a/docker/ingest-test/run_tests.sh
+++ b/docker/ingest-test/run_tests.sh
@@ -1,0 +1,75 @@
+#! /bin/bash
+
+usage() {
+cat <<_EOF_
+Usage: ./run_tests.sh [OPTIONS]...
+
+Runs the test suite.
+
+Available options:
+
+    --env-file              Location of file containing iRODS environment variables. 
+    --redis-container       The name of container running redis instance
+    --redis-host            Hostname for redis instance
+    --redis-port            Port for redis instance
+    --redis-db              Database number to be used with redis instance
+    --irods-host            Hostname for target iRODS server
+    --irods-container       Name of container running iRODS server
+    --specific-test         Dot-separated specific test to run
+    --host-mount-dir        Full path to directory on host for placing files
+    -h, --help              This message
+_EOF_
+    exit
+}
+
+env_file=icommands.env
+irods_host=icat.example.org
+redis_host=redis
+redis_port=6379
+redis_db=0
+host_mount_dir=/mnt/ingest_test_mount
+
+while [ -n "$1" ]; do
+    case "$1" in
+        --env-file)              shift; env_file=${1};;
+        --redis-container)       shift; redis_container=${1};;
+        --redis-host)            shift; redis_host=${1};;
+        --redis-port)            shift; redis_port=${1};;
+        --redis-db)              shift; redis_db=${1};;
+        --irods-host)            shift; irods_host=${1};;
+        --irods-container)       shift; irods_container=${1};;
+        --specific-test)         shift; specific_test=${1};;
+        --host-mount-dir)        shift; host_mount_dir=${1};;
+        -h|--help)               usage;;
+    esac
+    shift
+done
+
+#celery_broker_url="redis://${redis_host}:${redis_port}/${redis_db}"
+
+# Create a makeshift network between the containers, if present
+
+# Running iRODS 4.2.6
+# docker run --name irods-box -d -v /mnt/ingest_test_mount:/tmp/testdir:ro --hostname icat.example.org irods_4.2.6
+if [[ ${irods_container} ]]; then
+    container_links="--link ${irods_container}:${irods_host}"
+fi
+
+# Running Redis
+# docker run --rm --name some-redis -d redis:4.0.8
+if [[ ${redis_container} ]]; then
+    container_links="${container_links} --link ${redis_container}:${redis_host}"
+fi
+
+if [[ ${specific_test} ]]; then
+    test_case="-e TEST_CASE=irods_capability_automated_ingest.test.test_irods_sync.${specific_test}"
+fi
+
+docker run \
+    --rm \
+    --env-file ${env_file} \
+    ${test_case} \
+    ${container_links} \
+    -v ${host_mount_dir}:/tmp/testdir \
+    ingest-test
+echo $?

--- a/docker/launch_worker.sh
+++ b/docker/launch_worker.sh
@@ -13,12 +13,16 @@ Stop a running ingest job.
 Available options:
 
     --env-file              Location of file containing iRODS environment variables. 
+    --s3-keypair-file       Location of file containing an S3 keypair
     --redis-container       The name of container running redis instance
     --redis-host            Hostname for redis instance
     --redis-port            Port for redis instance
     --redis-db              Database number to be used with redis instance
-    --irods-container       Name of container running iRODS server
     --irods-host            Hostname for target iRODS server
+    --irods-container       Name of container running iRODS server
+    --s3-container          The name of container running S3 storage service
+    --s3-endpoint-domain    S3 endpoint domain
+    --src-dir               Full path to source S3 "folder"
     --concurrency           Number of Celery workers to stand up
     -h, --help              This message
 _EOF_
@@ -30,18 +34,24 @@ irods_host=icat.example.org
 redis_host=redis
 redis_port=6379
 redis_db=0
+s3_keypair_file=s3_keypair
+s3_endpoint_domain=minio
 concurrency=4
 
 while [ -n "$1" ]; do
     case "$1" in
-        --redis-container)  shift; redis_container=${1};;
-        --redis-host)       shift; redis_host=${1};;
-        --redis-port)       shift; redis_port=${1};;
-        --redis-db)         shift; redis_db=${1};;
-        --irods-host)       shift; irods_host=${1};;
-        --irods-container)  shift; irods_container=${1};;
-        --src-dir)          shift; src_dir=${1};;
-        --concurrency)      shift; concurrency=${1};;
+        --env-file)             shift; env_file=${1};;
+        --redis-container)      shift; redis_container=${1};;
+        --redis-host)           shift; redis_host=${1};;
+        --redis-port)           shift; redis_port=${1};;
+        --redis-db)             shift; redis_db=${1};;
+        --irods-host)           shift; irods_host=${1};;
+        --irods-container)      shift; irods_container=${1};;
+        --s3-keypair-file)      shift; s3_keypair_file=${1};;
+        --s3-container)         shift; s3_container=${1};;
+        --s3-endpoint-domain)   shift; s3_endpoint_domain=${1};;
+        --src-dir)              shift; src_dir=${1};;
+        --concurrency)          shift; concurrency=${1};;
         -h|--help)          usage;;
     esac
     shift
@@ -58,6 +68,10 @@ if [[ ${redis_container} ]]; then
     container_links="${container_links} --link ${redis_container}:${redis_host}"
 fi
 
+if [[ ${s3_container} ]]; then
+    container_links="${container_links} --link ${s3_container}:${s3_endpoint_domain}"
+fi
+
 # Uses default values
 docker run \
     --rm \
@@ -66,5 +80,6 @@ docker run \
     -e "CELERY_BROKER_URL=${celery_broker_url}" \
     ${container_links} \
     -v ${src_dir}:/data:ro \
+    -v ${s3_keypair}:/s3_keypair_file:ro \
     ingest-worker \
     -c ${concurrency}

--- a/docker/s3_keypair
+++ b/docker/s3_keypair
@@ -1,0 +1,2 @@
+minioadmin
+minioadmin

--- a/docker/start_job_s3.sh
+++ b/docker/start_job_s3.sh
@@ -13,14 +13,17 @@ Starts an ingest job targeting the source directory and destination collection.
 Available options:
 
     --env-file              Location of file containing iRODS environment variables. 
-    --s3-keypair-file       Location of file containing an S3 keypair
     --redis-container       The name of container running redis instance
     --redis-host            Hostname for redis instance
     --redis-port            Port for redis instance
     --redis-db              Database number to be used with redis instance
     --irods-host            Hostname for target iRODS server
     --irods-container       Name of container running iRODS server
-    --src-dir               Full path to source directory on host machine to be scanned
+    --s3-container          The name of container running S3 storage service
+    --s3-endpoint-domain    S3 endpoint domain
+    --s3-region_name        S3 region name
+    --s3-proxy-url          URL to proxy for S3 access
+    --src-dir               Full path to source S3 "folder"
     --dest-coll             Full path to desintation iRODS collection
     --ingest-options        Quoted string indicating options to pass to ingest application
     -h, --help              This message
@@ -28,12 +31,15 @@ _EOF_
     exit
 }
 
+#default values
 env_file=icommands.env
-s3_keypair_file=s3_keypair
 irods_host=icat.example.org
 redis_host=redis
 redis_port=6379
 redis_db=0
+s3_keypair_file=s3_keypair
+s3_endpoint_domain=s3.amazonaws.com
+s3_region_name=us-east-1
 
 while [ -n "$1" ]; do
     case "$1" in
@@ -44,6 +50,10 @@ while [ -n "$1" ]; do
         --redis-db)              shift; redis_db=${1};;
         --irods-host)            shift; irods_host=${1};;
         --irods-container)       shift; irods_container=${1};;
+        --s3-container)          shift; s3_container=${1};;
+        --s3-endpoint-domain)    shift; s3_endpoint_domain=${1};;
+        --s3-region-name)        shift; s3_region_name=${1};;
+        --s3-proxy-url)          shift; s3_proxy_url=${1};;
         --src-dir)               shift; src_dir=${1};;
         --dest-coll)             shift; dest_coll=${1};;
         --ingest-options)        shift; ingest_options=${1};;
@@ -63,15 +73,21 @@ if [[ ${redis_container} ]]; then
     container_links="${container_links} --link ${redis_container}:${redis_host}"
 fi
 
+if [[ ${s3_container} ]]; then
+    container_links="${container_links} --link ${s3_container}:${s3_endpoint_domain}"
+fi
+
+# Add S3 ingest options
+ingest_options="${ingest_options} --s3_keypair /s3_keypair_file --s3_endpoint_domain ${s3_endpoint_domain} --s3_region_name ${s3_region_name}"
+
 docker run \
     --rm \
     --env-file ${env_file} \
     -e "CELERY_BROKER_URL=${celery_broker_url}" \
-    -v ${src_dir}:/data:ro \
     -v ${s3_keypair}:/s3_keypair_file:ro \
     ${container_links} \
     ingest \
     start \
-    /data \
+    ${src_dir} \
     ${dest_coll} \
     ${ingest_options}

--- a/irods_capability_automated_ingest/examples/no_retry.py
+++ b/irods_capability_automated_ingest/examples/no_retry.py
@@ -1,6 +1,6 @@
 from irods_capability_automated_ingest.core import Core
 from irods_capability_automated_ingest.utils import Operation
-from redis import StrictRedis
+from irods_capability_automated_ingest.sync_utils import get_redis
 
 class event_handler(Core):
 
@@ -13,7 +13,7 @@ class event_handler(Core):
         target = meta["target"]
         path = meta["path"]
 
-        r = StrictRedis()
+        r = get_redis(meta['config'])
         failures = r.get("failures:"+path)
         if failures is None:
             failures = 0

--- a/irods_capability_automated_ingest/examples/post_job.py
+++ b/irods_capability_automated_ingest/examples/post_job.py
@@ -1,6 +1,5 @@
 from irods_capability_automated_ingest.core import Core
 from irods_capability_automated_ingest.utils import Operation
-from redis import StrictRedis
 
 class event_handler(Core):
 

--- a/irods_capability_automated_ingest/examples/pre_job.py
+++ b/irods_capability_automated_ingest/examples/pre_job.py
@@ -1,6 +1,5 @@
 from irods_capability_automated_ingest.core import Core
 from irods_capability_automated_ingest.utils import Operation
-from redis import StrictRedis
 
 class event_handler(Core):
 

--- a/irods_capability_automated_ingest/examples/retry.py
+++ b/irods_capability_automated_ingest/examples/retry.py
@@ -1,6 +1,6 @@
 from irods_capability_automated_ingest.core import Core
 from irods_capability_automated_ingest.utils import Operation
-from redis import StrictRedis
+from irods_capability_automated_ingest.sync_utils import get_redis
 
 class event_handler(Core):
 
@@ -21,7 +21,7 @@ class event_handler(Core):
         path = meta["path"]
         target = meta["target"]
 
-        r = StrictRedis()
+        r = get_redis(meta['config'])
         failures = r.get("failures:"+path)
         if failures is None:
             failures = 0

--- a/irods_capability_automated_ingest/irods_sync.py
+++ b/irods_capability_automated_ingest/irods_sync.py
@@ -83,6 +83,7 @@ def handle_start(args):
     data["s3_region_name"] = args.s3_region_name
     data["s3_keypair"] = args.s3_keypair
     data["s3_proxy_url"] = args.s3_proxy_url
+    data["s3_secure_connection"] = not args.s3_insecure_connection
     data["exclude_file_type"] = ex_arg_list
     data['exclude_file_name'] = [ ''.join(r) for r in args.exclude_file_name ]
     data['exclude_directory_name'] = [ ''.join(r) for r in args.exclude_directory_name ]
@@ -126,6 +127,7 @@ def main():
     parser_start.add_argument('--s3_region_name', action="store", type=str, default='us-east-1', help='S3 region name')
     parser_start.add_argument('--s3_keypair', action="store", type=str, default=None, help='Path to S3 keypair file')
     parser_start.add_argument('--s3_proxy_url', action="store", type=str, default=None, help='URL to proxy for S3 access')
+    parser_start.add_argument('--s3_insecure_connection', action="store_true", default=False, help='Do not use SSL when connecting to S3 endpoint')
     parser_start.add_argument('--exclude_file_type', nargs=1, action="store", default='none', help='types of files to exclude: regular, directory, character, block, socket, pipe, link')
     parser_start.add_argument('--exclude_file_name', type=list, nargs='+', action="store", default='none', help='a list of space-separated python regular expressions defining the file names to exclude such as "(\S+)exclude" "(\S+)\.hidden"')
     parser_start.add_argument('--exclude_directory_name', type=list, nargs='+', action="store", default='none', help='a list of space-separated python regular expressions defining the directory names to exclude such as "(\S+)exclude" "(\S+)\.hidden"')

--- a/irods_capability_automated_ingest/sync_task.py
+++ b/irods_capability_automated_ingest/sync_task.py
@@ -419,7 +419,7 @@ def sync_entry(self, meta, cls, datafunc, metafunc):
         utf8_escaped_abspath = abspath.encode('utf8', 'surrogateescape')
         b64_path_str = base64.b64encode(utf8_escaped_abspath)
 
-        unicode_error_filename = 'irods_UnicodeEncodeError_' + str(b64_path_str.decode('utf8'))
+        unicode_error_filename = 'irods_UnicodeEncodeError_' + str(b64_path_str.decode('utf8')).rstrip('/')
 
         logger.warning('sync_entry raised UnicodeEncodeError while syncing path:' + str(utf8_escaped_abspath))
 

--- a/irods_capability_automated_ingest/sync_task.py
+++ b/irods_capability_automated_ingest/sync_task.py
@@ -280,10 +280,14 @@ def sync_path(self, meta):
             endpoint_domain = meta.get('s3_endpoint_domain')
             s3_access_key = meta.get('s3_access_key')
             s3_secret_key = meta.get('s3_secret_key')
+            s3_secure_connection = meta.get('s3_secure_connection')
+            if s3_secure_connection is None:
+                s3_secure_connection = True
             client = Minio(
                          endpoint_domain,
                          access_key=s3_access_key,
                          secret_key=s3_secret_key,
+                         secure=s3_secure_connection,
                          http_client=httpClient)
 
             # Split provided path into bucket and source folder "prefix"


### PR DESCRIPTION
This change cleans up the automated ingest test suite and ensures
that all tests are passing insofar as the server allows (Github issue
numbers referenced where relevant for skipping).

iRODS and redis server information is currently hard-coded for
the tests. iRODS client information is also hard-coded.

When fixing the UnicodeEncodeError tests, it appears that it is able
to create a collection in iRODS with a contained data object with no
name, leading to a data object to which one cannot refer. It must be
removed directly from the database. There is an issue in the main repo
for this: https://github.com/irods/irods/issues/4494