### PR TITLE
[#147][#157] Allow running workers with env only

### DIFF
--- a/irods_capability_automated_ingest/sync_irods.py
+++ b/irods_capability_automated_ingest/sync_irods.py
@@ -310,12 +310,15 @@ def irods_session(handler_module, meta, logger, **options):
 
     key = json.dumps(kwargs) # todo add timestamp of env file to key
 
-    with open(env_file) as irods_env:
-        irods_env_as_json =  json.load(irods_env)
-        if 'irods_ssl_ca_certificate_file' in irods_env_as_json:
-            kwargs['ssl_context'] = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH,
-                                                               cafile=irods_env_as_json['irods_ssl_ca_certificate_file'],
-                                                               capath=None, cadata=None)
+    if env_file:
+        with open(env_file) as irods_env:
+            irods_env_as_json =  json.load(irods_env)
+            verify_server = irods_env_as_json.get('irods_ssl_verify_server')
+            ca_file = irods_env_as_json.get('irods_ssl_ca_certificate_file')
+            if verify_server and verify_server != 'none' and ca_file:
+                kwargs['ssl_context'] = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH,
+                                                                   cafile=ca_file,
+                                                                   capath=None, cadata=None)
 
     if not key in irods_session_map:
         # TODO: #42 - pull out 10 into configuration


### PR DESCRIPTION
`$IRODS_ENVIRONMENT_FILE` is still supported but if the env contains the
supported environment variables, this makes deployment of worker nodes
much easier. Here are the supported/expected environment variables:
```
    IRODS_HOST
    IRODS_PORT
    IRODS_USER_NAME
    IRODS_ZONE_NAME
    IRODS_PASSWORD
```
If any of these is missing, an environment file in JSON format is
expected to be at the path specified by `$IRODS_ENVIRONMENT_FILE`. The
environment file should contain at least the following information:
```
    {
        "irods_host": <string>,
        "irods_port": <int>,
        "irods_user": <string>,
        "irods_zone_name": <string>
    }
```
An `.irodsA` file is expected to be in the home directory of the Linux
user running the Celery workers on a given node in order to authenticate
with iRODS.