### PR TITLE
[#159] add performance benchmark test harness

### DIFF
--- a/docker/performance_testing/Dockerfile.ingest_worker
+++ b/docker/performance_testing/Dockerfile.ingest_worker
@@ -1,0 +1,7 @@
+FROM python:latest
+
+ARG PIP_PACKAGE="irods-capability-automated-ingest"
+
+RUN pip install ${PIP_PACKAGE} docker-compose
+
+ENTRYPOINT ["celery", "-A", "irods_capability_automated_ingest.sync_task", "worker", "-Q", "restart,path,file"]

--- a/docker/performance_testing/README.md
+++ b/docker/performance_testing/README.md
@@ -1,0 +1,44 @@
+variables for performance tests:
+1. code that is running
+2. number of files ingested
+3. traffic control delay
+4. number of workers (nodes x --concurrency?)
+
+- Prerequisites
+Running this project has a dependency on the [iRODS Testing Environment](https://github.com/irods/irods_testing_environment).
+
+```
+# set up virtualenv
+virtualenv -p python3 ~/ingest_performance_testing_env
+# install docker-compose so we can use pieces of the testing environment
+pip install docker-compose ; # recommended: virtualenv!
+# build the project (change SHA/repo to match what you are testing)
+docker-compose --build-arg PIP_PACKAGE=git+https://github.com/irods/irods_capability_automated_ingest@master build ;
+# stand up the project
+docker-compose up -d ;
+# install iRODS packages
+docker exec -e DEBIAN_FRONTEND=noninteractive performance_testing_irods-catalog-provider_1 apt install -y irods-database-plugin-postgres ;
+# this is not strictly speaking necessary, but you do need this repo somewhere on the host machine
+git clone https://github.com/irods/irods_testing_environment ;
+# setup iRODS server using default settings
+python ./irods_testing_environment/setup.py --project-directory ./irods_capability_automated_ingest/docker/performance_testing -d postgres:10.12 -p ubuntu:18.04 --exclude-irods-catalog-consumers-setup -v ;
+```
+
+- Turn some knobs
+```
+# install some networking tools (ingest-worker service runs with NETWORK_ADMIN enabled)
+docker exec performance_testing_ingest-worker_1 apt update && apt install -y iputils-ping iproute2 ;
+# some examples of what you can do with tc (traffic controller)
+docker exec performance_testing_ingest-worker_1 tc qdisc add dev eth0 root netem delay 100ms # to add rule
+docker exec performance_testing_ingest-worker_1 tc qdisc show dev eth0 # to show rules
+docker exec performance_testing_ingest-worker_1 tc qdisc del dev eth0 root netem # to delete rule
+# scale workers (up or down)
+docker-compose up --scale ingest-worker=N
+```
+
+- Run an ingest job
+```
+docker exec -e CELERY_BROKER_URL=redis://some-redis:6379/0 performance_testing_ingest-worker_1 python -m irods_capability_automated_ingest.irods_sync start --synchronous --progress /wormhole /tempZone/home/rods/ingested # plus whatever else
+```
+
+In this example, we are running the ingest job inside an ingest-worker service instance container, but you can also run this on the host machine if you so desire (need to configure networking with Redis and map the volume mounts appropriately).

--- a/docker/performance_testing/docker-compose.yml
+++ b/docker/performance_testing/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3'
+
+services:
+    catalog:
+        image: postgres:10.12
+        environment:
+            - POSTGRES_PASSWORD=testpassword
+
+    irods-catalog-provider:
+        build:
+            context: https://raw.githubusercontent.com/irods/irods_testing_environment/main/projects/ubuntu-18.04/Dockerfile
+        volumes:
+            - "/tmp/mountdir:/wormhole:ro"
+        depends_on:
+            - catalog
+
+    some-redis:
+        image: redis
+
+    ingest-worker:
+        build:
+            context: .
+            dockerfile: Dockerfile.ingest_worker
+        environment:
+            IRODS_HOST: irods-catalog-provider
+            IRODS_PORT: 1247
+            IRODS_USER_NAME: rods
+            IRODS_ZONE_NAME: tempZone
+            IRODS_PASSWORD: rods
+            CELERY_BROKER_URL: redis://some-redis:6379/0
+        cap_add:
+            - NET_ADMIN
+        volumes:
+            - "/tmp/mountdir:/wormhole:ro"
+        depends_on:
+            - some-redis
+            - irods-catalog-provider


### PR DESCRIPTION
This change adds a Docker Compose project which sets up an environment
for testing performance of the ingest tool in various conditions. The
following variables can be adjusted:
    - number of files ingested (as well as subdirectory depth)
    - traffic control delay
    - number of workers (nodes x --concurrency?)