### PR TITLE
Fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ The example diagrams below show a filesystem scanner and a landing zone.
 
 ![Automated Ingest: Landing Zone Diagram](capability_automated_ingest_landing_zone.jpg)
 
+## Supported/Tested Python versions
+- 3.7
+- 3.8
+- 3.9
+- 3.10
+
 ## Usage options
 
 ### Redis options
@@ -181,7 +187,7 @@ celery -A irods_capability_automated_ingest.sync_task worker -l error -Q restart
 **Note:** Make sure queue names match those of the ingest job (default queue names shown here).
 
 #### Run tests
-**Note:** The test suite requires Python version >=3.5.
+**Note:** The test suite requires Python version >=3.7.
 **Note:** The tests should be run without running Celery workers or with an unused redis database.
 ```
 python -m irods_capability_automated_ingest.test.test_irods_sync

--- a/docker/ingest-test/icommands.env
+++ b/docker/ingest-test/icommands.env
@@ -4,5 +4,5 @@ IRODS_USER_NAME=rods
 IRODS_ZONE_NAME=tempZone
 IRODS_ENVIRONMENT_FILE=/irods_environment.json
 IRODS_PASSWORD=rods
-PIP_PACKAGE=git+https://github.com/irods/irods_capability_automated_ingest@master
+PIP_PACKAGE=git+https://github.com/irods/irods_capability_automated_ingest@main
 TEST_CASE=irods_capability_automated_ingest.test.test_irods_sync

--- a/docker/ingest-test/test/Dockerfile
+++ b/docker/ingest-test/test/Dockerfile
@@ -1,10 +1,6 @@
-FROM python:3.5
+FROM python:3.10
 
 RUN apt update && apt install -y netcat
-
-ARG PIP_PACKAGE="irods-capability-automated-ingest"
-
-RUN pip install ${PIP_PACKAGE}
 
 COPY irods_environment.json /
 

--- a/docker/ingest-test/test/run_tests.sh
+++ b/docker/ingest-test/test/run_tests.sh
@@ -1,6 +1,6 @@
-#! /bin/bash
+#! /bin/bash -ex
 
-pip install --upgrade ${PIP_PACKAGE}
+pip install ${PIP_PACKAGE}
 
 # Wait until the provider is up and accepting connections.
 until nc -z icat.example.org 1247; do
@@ -9,4 +9,4 @@ done
 
 sleep 10
 
-python -m unittest ${TEST_CASE}
+python -m unittest -v ${TEST_CASE}

--- a/irods_capability_automated_ingest/custom_event_handler.py
+++ b/irods_capability_automated_ingest/custom_event_handler.py
@@ -27,7 +27,7 @@ class custom_event_handler(object):
         event_handler_str = event_handler_key.get_key().split('::')
         uuid_ = event_handler_str[1]
 
-        eh_file_name = "event_handler" + job_name + uuid_
+        eh_file_name = "event_handler" + job_name.replace('.', '__') + uuid_
         eh_path = "/tmp/" + eh_file_name + ".py"
 
         #if the file does not already exist, create new file

--- a/irods_capability_automated_ingest/redis_key.py
+++ b/irods_capability_automated_ingest/redis_key.py
@@ -30,7 +30,7 @@ class redis_key_handle(object):
         raise RuntimeError("max retries")
 
     def get_key(self):
-        return str(self.category + ':/' + self.identifier)
+        return str(self.category + self.delimiter + self.identifier)
 
     def get_value(self):
         if self.get_key() is None:

--- a/irods_capability_automated_ingest/test/test_irods_sync.py
+++ b/irods_capability_automated_ingest/test/test_irods_sync.py
@@ -1093,7 +1093,6 @@ class Test_register_as_replica(automated_ingest_test_context, unittest.TestCase)
         self.do_register_as_replica_no_assertions(event_handler, register_as_replica_job)
         self.do_assert_failed_queue(job_name=register_as_replica_job)
 
-    @unittest.skip('irods/irods#4622')
     def test_update_with_resc_name_with_two_replicas(self):
         put_job = 'test_update_with_resc_name_with_two_replicas.put'
         self.do_put(
@@ -1118,7 +1117,6 @@ class Test_register_as_replica(automated_ingest_test_context, unittest.TestCase)
         self.do_assert_failed_queue(count=None, job_name=update_replica_job)
         self.do_assert_retry_queue(count=None, job_name=update_replica_job)
 
-    @unittest.skip('irods/irods#4622')
     def test_update_root_with_resc_name_with_two_replicas(self):
         put_job = 'test_update_root_with_resc_name_with_two_replicas.put'
         self.do_put(
@@ -1180,7 +1178,6 @@ class Test_register_as_replica(automated_ingest_test_context, unittest.TestCase)
             session.resources.add_child(REGISTER_RESC2, REGISTER_RESC2A)
 
     # replica with another replica in hier
-    @unittest.skip('irods/irods#4622')
     def test_register_as_replica_with_resc_name_with_another_replica_in_hier(self):
         put_job = 'test_register_as_replica_with_resc_name_with_another_replica_in_hier.put'
         self.do_put_to_child(job_name = put_job)
@@ -1384,7 +1381,6 @@ class Test_register(automated_ingest_test_context, unittest.TestCase):
             '/tempZ/home/rods',
             job_name = 'test_register_to_existing_zone_substring')
 
-    @unittest.skip('irods/irods#4621')
     def test_register_to_existing_zone_superstring(self):
         self.do_register_to_invalid_zone(
             '/tempZoneMore/home/rods',

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,19 @@ setup(
     author='iRODS Consortium',
     author_email='support@irods.org',
     license='BSD',
+    python_requires=">=3.7,",
     classifiers=[
-        'License :: OSI Approved :: BSD License',
         'Development Status :: 4 - Beta',
-        'Programming Language :: Python :: 3.5',
-        'Operating System :: POSIX :: Linux'
+        'License :: OSI Approved :: BSD License',
+        'Natural Language :: English',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10'
     ],
     keywords='irods automated ingest landingzone filesystem',
     packages=find_packages(),
@@ -34,14 +42,14 @@ setup(
         'minio',
         'flask',
         'flask-restful',
-        'python-irodsclient==1.1.1',
+        'python-irodsclient>=1.1.1, <2.0.0',
         'python-redis-lock>=3.2.0',
-        'redis>=2.10.6, <3.0.0',
-        'celery[redis]>=4.2.1, <4.3.0',
+        'redis>=3.4.1, <4.0.0',
+        'celery[redis]>=5.2.2, <5.3.0',
         'scandir',
         'structlog>=18.1.0',
         'progressbar2',
-        'billiard>=3.5.0.2, <3.6.0'
+        'billiard>=3.6.4.0, <4.0'
     ],
     setup_requires=['setuptools>=38.6.0'],
     entry_points={


### PR DESCRIPTION
Tests run and pass in the `docker/ingest-test` project. Still trying to sort out if the version bump is appropriate at this point, but Py3.5 is no longer working with the existing dependencies