### PR TITLE
[#177] Fix wrong exit code with --synchronous option

### DIFF
--- a/irods_capability_automated_ingest/sync_actions.py
+++ b/irods_capability_automated_ingest/sync_actions.py
@@ -89,7 +89,7 @@ def monitor_job(job_name, progress, config):
             time.sleep(1)
 
     failures = job.failures_handle().get_value()
-    if failures != 0:
+    if failures is not None and failures != 0:
         return -1
     else:
         return 0


### PR DESCRIPTION
Variable failures equals None when a job have successfully executed

---

Identical to https://github.com/irods/irods_capability_automated_ingest/pull/178