### PR TITLE
Fix exclude_file_name being ignored

### DIFF
--- a/irods_capability_automated_ingest/scanner.py
+++ b/irods_capability_automated_ingest/scanner.py
@@ -43,7 +43,7 @@ class scanner(object):
         for f in file_regex:
             file_match = None != f.match(full_path)
             if(file_match == True):
-                break
+                return True
 
         try:
             if mode is None:
@@ -101,7 +101,7 @@ class filesystem_scanner(scanner):
 
         try:
             if self.exclude_file_type(dir_regex, file_regex, full_path, logger, mode):
-                return full_path, obj_stats
+                raise ContinueException
 
             if not obj.is_symlink() and not bool(mode & stat.S_IRGRP):
                 logger.error(


### PR DESCRIPTION
Due to the recent refactor and lack of test coverage in this area, `--exclude_file_name` has been broken since 0.4.0. This is because the implementation moved control blocks but was not updated properly to adapt to its new context. This fix is not a complete solution, but allows the option to be used as expected once again.