### PR TITLE
changes for next release (v0.4.2)

### DIFF
--- a/docker/ingest-test/test/Dockerfile
+++ b/docker/ingest-test/test/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.10
+FROM python:3.11
 
-RUN apt update && apt install -y netcat
+RUN apt update && apt install -y netcat-traditional
 
 COPY irods_environment.json /
 

--- a/irods_capability_automated_ingest/test/test_irods_sync.py
+++ b/irods_capability_automated_ingest/test/test_irods_sync.py
@@ -24,6 +24,8 @@ from irods.data_object import irods_dirname, irods_basename
 import irods_capability_automated_ingest.examples
 import irods.keywords as kw
 
+os.environ["CELERY_BROKER_URL"] = "redis://redis:6379/0"
+
 LOG_FILE = "/tmp/a"
 
 ZONENAME = "tempZone"
@@ -284,8 +286,6 @@ def event_handler_path(eh_name):
 
 class automated_ingest_test_context(object):
     def setUp(self):
-        os.environ["CELERY_BROKER_URL"] = "redis://redis:6379/0"
-
         irmtrash()
         clear_redis()
         delete_collection_if_exists(PATH_TO_COLLECTION)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10'
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11'
     ],
     keywords='irods automated ingest landingzone filesystem',
     packages=find_packages(),


### PR DESCRIPTION
  - log Python 3.11 compatibility
  - apply `CELERY_BROKER_URL` environment variable change for all tests