### PR TITLE
[#129] single stream put from S3

### DIFF
--- a/irods_capability_automated_ingest/irods_sync.py
+++ b/irods_capability_automated_ingest/irods_sync.py
@@ -130,6 +130,7 @@ def handle_start(args):
     data["s3_keypair"] = args.s3_keypair
     data["s3_proxy_url"] = args.s3_proxy_url
     data["s3_secure_connection"] = not args.s3_insecure_connection
+    data["s3_multipart_chunksize_in_mib"] = args.s3_multipart_chunksize_in_mib
     data["exclude_file_type"] = ex_arg_list
     data['exclude_file_name'] = [''.join(r) for r in args.exclude_file_name]
     data['exclude_directory_name'] = [
@@ -198,6 +199,9 @@ def main():
                               type=str, default=None, help='URL to proxy for S3 access')
     parser_start.add_argument('--s3_insecure_connection', action="store_true",
                               default=False, help='Do not use SSL when connecting to S3 endpoint')
+    parser_start.add_argument('--s3_multipart_chunksize_in_mib',action="store", type=int,
+                              default=8, choices=range(5, 5001), metavar="[5-5000]",
+                              help='Chunk size in mebibytes for multipart S3 uploads. Minimum part size is 5 MiB and the maximum part size is 5000 MiB.')
     parser_start.add_argument('--exclude_file_type', nargs=1, action="store", default='none',
                               help='types of files to exclude: regular, directory, character, block, socket, pipe, link')
     parser_start.add_argument('--exclude_file_name', type=list, nargs='+', action="store", default='none',

--- a/irods_capability_automated_ingest/scanner.py
+++ b/irods_capability_automated_ingest/scanner.py
@@ -165,9 +165,8 @@ class s3_scanner(scanner):
         endpoint_domain = meta.get('s3_endpoint_domain')
         s3_access_key = meta.get('s3_access_key')
         s3_secret_key = meta.get('s3_secret_key')
-        s3_secure_connection = meta.get('s3_secure_connection')
-        if s3_secure_connection is None:
-            s3_secure_connection = True
+        s3_secure_connection = meta.get('s3_secure_connection', True)
+       
         client = Minio(
             endpoint_domain,
             access_key=s3_access_key,

--- a/irods_capability_automated_ingest/sync_actions.py
+++ b/irods_capability_automated_ingest/sync_actions.py
@@ -106,19 +106,14 @@ def start_job(data):
     s3_region_name = data["s3_region_name"]
     s3_endpoint_domain = data["s3_endpoint_domain"]
     s3_keypair = data["s3_keypair"]
-
+    s3_multipart_chunksize = data["s3_multipart_chunksize_in_mib"]
     logger = sync_logging.get_sync_logger(logging_config)
     data_copy = data.copy()
 
     if s3_keypair is not None:
-        data_copy['s3_region_name'] = s3_region_name
-        data_copy['s3_endpoint_domain'] = s3_endpoint_domain
-        data_copy['s3_keypair'] = s3_keypair
-        # parse s3 keypair
-        if s3_keypair is not None:
-            with open(s3_keypair) as f:
-                data_copy['s3_access_key'] = f.readline().rstrip()
-                data_copy['s3_secret_key'] = f.readline().rstrip()
+        with open(s3_keypair) as f:
+            data_copy['s3_access_key'] = f.readline().rstrip()
+            data_copy['s3_secret_key'] = f.readline().rstrip()
         # set source
         src_abs = src_path
     else:


### PR DESCRIPTION
This fixes the "File not found error" that occurs when trying to run a PUT or PUT_SYNC for files from an S3 resource. I am using Minio to get the file from the S3 bucket. Currently can not use parallelization to do the put for S3 objects, which will need to be worked on. Not sure what to do with that at this point.  I have also included checksum comparison with the Etag for both normal files in an S3 bucket and also multipart upload files. I am not sure if this is the correct way to do the checksum, so feedback there would be good. The default chunk size for multipart uploads to Amazon S3 is 8 MB, but I have read online that it may not always be the same, so I have added a command line argument to the ingest job to specify a different chunk size. 