### PR TITLE
changed ```REGISTER``` to ```REGISTER_SYNC``` in example event handlers for metadata.py. 

### DIFF
--- a/irods_capability_automated_ingest/examples/metadata.py
+++ b/irods_capability_automated_ingest/examples/metadata.py
@@ -29,7 +29,7 @@ class event_handler(Core):
 
     @staticmethod
     def operation(session, meta, **options):
-        return Operation.REGISTER
+        return Operation.REGISTER_SYNC
 
 
 


### PR DESCRIPTION
Addresses #212. Just changed operation type. 