### PR TITLE
Add *args to all example event handler methods, and add tests for pre/post event handler methods

### DIFF
--- a/irods_capability_automated_ingest/examples/append_json.py
+++ b/irods_capability_automated_ingest/examples/append_json.py
@@ -8,6 +8,6 @@ class event_handler(Core):
         return Operation.NO_OP
 
     @staticmethod
-    def pre_data_obj_create(hdlr_mod, logger, session, meta, **options):
+    def pre_data_obj_create(hdlr_mod, logger, session, meta, *args, **options):
         if meta["append_json"] != "append_json":
             raise RuntimeError("append_json error")

--- a/irods_capability_automated_ingest/examples/coll_create_pre_and_post.py
+++ b/irods_capability_automated_ingest/examples/coll_create_pre_and_post.py
@@ -1,0 +1,35 @@
+import os
+
+from irods_capability_automated_ingest.core import Core
+from irods_capability_automated_ingest.utils import Operation
+
+OPERATION = Operation.REGISTER_SYNC
+
+class event_handler(Core):
+    @staticmethod
+    def operation(session, meta, **options):
+        return OPERATION
+
+    @staticmethod
+    def pre_coll_create(hdlr_mod, logger, session, meta, *args, **options):
+        created_collection = meta["target"]
+        parent_of_created_collection = '/'.join(created_collection.split('/')[:-1])
+
+        attribute = "pre_coll_create"
+        value = created_collection
+        unit = OPERATION.name
+
+        coll = session.collections.get(parent_of_created_collection)
+        coll.metadata.add(attribute, value, unit)
+
+    @staticmethod
+    def post_coll_create(hdlr_mod, logger, session, meta, *args, **options):
+        created_collection = meta["target"]
+        parent_of_created_collection = '/'.join(created_collection.split('/')[:-1])
+
+        attribute = "post_coll_create"
+        value = created_collection
+        unit = OPERATION.name
+
+        coll = session.collections.get(parent_of_created_collection)
+        coll.metadata.add(attribute, value, unit)

--- a/irods_capability_automated_ingest/examples/coll_modify_pre_and_post.py
+++ b/irods_capability_automated_ingest/examples/coll_modify_pre_and_post.py
@@ -1,0 +1,33 @@
+import os
+
+from irods_capability_automated_ingest.core import Core
+from irods_capability_automated_ingest.utils import Operation
+
+OPERATION = Operation.REGISTER_SYNC
+
+class event_handler(Core):
+    @staticmethod
+    def operation(session, meta, **options):
+        return OPERATION
+
+    @staticmethod
+    def pre_coll_modify(hdlr_mod, logger, session, meta, *args, **options):
+        modified_collection = meta["target"]
+
+        attribute = "pre_coll_modify"
+        value = meta['job_name']
+        unit = OPERATION.name
+
+        coll = session.collections.get(modified_collection)
+        coll.metadata.add(attribute, value, unit)
+
+    @staticmethod
+    def post_coll_modify(hdlr_mod, logger, session, meta, *args, **options):
+        modified_collection = meta["target"]
+
+        attribute = "post_coll_modify"
+        value = meta['job_name']
+        unit = OPERATION.name
+
+        coll = session.collections.get(modified_collection)
+        coll.metadata.add(attribute, value, unit)

--- a/irods_capability_automated_ingest/examples/data_obj_create_pre_and_post.py
+++ b/irods_capability_automated_ingest/examples/data_obj_create_pre_and_post.py
@@ -1,0 +1,35 @@
+import os
+
+from irods_capability_automated_ingest.core import Core
+from irods_capability_automated_ingest.utils import Operation
+
+OPERATION = Operation.REGISTER_SYNC
+
+class event_handler(Core):
+    @staticmethod
+    def operation(session, meta, **options):
+        return OPERATION
+
+    @staticmethod
+    def pre_data_obj_create(hdlr_mod, logger, session, meta, *args, **options):
+        created_data_object_path = meta["target"]
+        parent_collection_of_created_data_object = '/'.join(created_data_object_path.split('/')[:-1])
+
+        attribute = "pre_data_obj_create"
+        value = created_data_object_path
+        unit = OPERATION.name
+
+        coll = session.collections.get(parent_collection_of_created_data_object)
+        coll.metadata.add(attribute, value, unit)
+
+    @staticmethod
+    def post_data_obj_create(hdlr_mod, logger, session, meta, *args, **options):
+        created_data_object_path = meta["target"]
+        parent_collection_of_created_data_object = '/'.join(created_data_object_path.split('/')[:-1])
+
+        attribute = "post_data_obj_create"
+        value = created_data_object_path
+        unit = OPERATION.name
+
+        coll = session.collections.get(parent_collection_of_created_data_object)
+        coll.metadata.add(attribute, value, unit)

--- a/irods_capability_automated_ingest/examples/data_obj_modify_pre_and_post.py
+++ b/irods_capability_automated_ingest/examples/data_obj_modify_pre_and_post.py
@@ -1,0 +1,35 @@
+import os
+
+from irods_capability_automated_ingest.core import Core
+from irods_capability_automated_ingest.utils import Operation
+
+OPERATION = Operation.REGISTER_SYNC
+
+class event_handler(Core):
+    @staticmethod
+    def operation(session, meta, **options):
+        return OPERATION
+
+    @staticmethod
+    def pre_data_obj_modify(hdlr_mod, logger, session, meta, *args, **options):
+        created_data_object_path = meta["target"]
+        parent_collection_of_created_data_object = '/'.join(created_data_object_path.split('/')[:-1])
+
+        attribute = "pre_data_obj_modify"
+        value = created_data_object_path
+        unit = OPERATION.name
+
+        coll = session.collections.get(parent_collection_of_created_data_object)
+        coll.metadata.add(attribute, value, unit)
+
+    @staticmethod
+    def post_data_obj_modify(hdlr_mod, logger, session, meta, *args, **options):
+        created_data_object_path = meta["target"]
+        parent_collection_of_created_data_object = '/'.join(created_data_object_path.split('/')[:-1])
+
+        attribute = "post_data_obj_modify"
+        value = created_data_object_path
+        unit = OPERATION.name
+
+        coll = session.collections.get(parent_collection_of_created_data_object)
+        coll.metadata.add(attribute, value, unit)

--- a/irods_capability_automated_ingest/examples/no_retry.py
+++ b/irods_capability_automated_ingest/examples/no_retry.py
@@ -9,7 +9,7 @@ class event_handler(Core):
         return Operation.NO_OP
 
     @staticmethod
-    def pre_data_obj_create(hdlr_mod, logger, session, meta, **options):
+    def pre_data_obj_create(hdlr_mod, logger, session, meta, *args, **options):
         target = meta["target"]
         path = meta["path"]
 

--- a/irods_capability_automated_ingest/examples/register_with_peps.py
+++ b/irods_capability_automated_ingest/examples/register_with_peps.py
@@ -8,41 +8,41 @@ class event_handler(Core):
         return Operation.REGISTER_SYNC
 
     @staticmethod
-    def pre_data_obj_create(hdlr_mod, logger, session, meta, **options):
+    def pre_data_obj_create(hdlr_mod, logger, session, meta, *args, **options):
         logical_path = meta["target"]
         logger.info("pre_data_obj_create:[" + logical_path + "]")
 
     @staticmethod
-    def post_data_obj_create(hdlr_mod, logger, session, meta, **options):
+    def post_data_obj_create(hdlr_mod, logger, session, meta, *args, **options):
         logical_path = meta["target"]
         logger.info("post_data_obj_create:[" + logical_path + "]")
 
     @staticmethod
-    def pre_coll_create(hdlr_mod, logger, session, meta, **options):
+    def pre_coll_create(hdlr_mod, logger, session, meta, *args, **options):
         logical_path = meta["target"]
         logger.info("pre_coll_create:[" + logical_path + "]")
 
     @staticmethod
-    def post_coll_create(hdlr_mod, logger, session, meta, **options):
+    def post_coll_create(hdlr_mod, logger, session, meta, *args, **options):
         logical_path = meta["target"]
         logger.info("post_coll_create:[" + logical_path + "]")
 
     @staticmethod
-    def pre_data_obj_modify(hdlr_mod, logger, session, meta, **options):
+    def pre_data_obj_modify(hdlr_mod, logger, session, meta, *args, **options):
         logical_path = meta["target"]
         logger.info("pre_data_obj_modify:[" + logical_path + "]")
 
     @staticmethod
-    def post_data_obj_modify(hdlr_mod, logger, session, meta, **options):
+    def post_data_obj_modify(hdlr_mod, logger, session, meta, *args, **options):
         logical_path = meta["target"]
         logger.info("post_data_obj_modify:[" + logical_path + "]")
 
     @staticmethod
-    def pre_coll_modify(hdlr_mod, logger, session, meta, **options):
+    def pre_coll_modify(hdlr_mod, logger, session, meta, *args, **options):
         logical_path = meta["target"]
         logger.info("pre_coll_modify:[" + logical_path + "]")
 
     @staticmethod
-    def post_coll_modify(hdlr_mod, logger, session, meta, **options):
+    def post_coll_modify(hdlr_mod, logger, session, meta, *args, **options):
         logical_path = meta["target"]
         logger.info("post_coll_modify:[" + logical_path + "]")

--- a/irods_capability_automated_ingest/examples/retry.py
+++ b/irods_capability_automated_ingest/examples/retry.py
@@ -17,7 +17,7 @@ class event_handler(Core):
         return Operation.NO_OP
 
     @staticmethod
-    def pre_data_obj_create(hdlr_mod, logger, session, meta, **options):
+    def pre_data_obj_create(hdlr_mod, logger, session, meta, *args, **options):
         path = meta["path"]
         target = meta["target"]
 

--- a/irods_capability_automated_ingest/examples/timeout.py
+++ b/irods_capability_automated_ingest/examples/timeout.py
@@ -13,5 +13,5 @@ class event_handler(Core):
         return 1
 
     @staticmethod
-    def pre_data_obj_create(hdlr_mod, logger, session, meta, **options):
+    def pre_data_obj_create(hdlr_mod, logger, session, meta, *args, **options):
         time.sleep(2)

--- a/irods_capability_automated_ingest/scanner.py
+++ b/irods_capability_automated_ingest/scanner.py
@@ -140,7 +140,7 @@ class filesystem_scanner(scanner):
         # target2
         return join(meta["target"], relpath(path, start=meta["root"]))
 
-    def upload_file(self, logger, session, meta, exists, **options):
+    def upload_file(self, logger, session, meta, op, exists, **options):
         """
         Function called from sync_irods.sync_file and sync_irods.upload_file for local files
 
@@ -155,9 +155,6 @@ class filesystem_scanner(scanner):
         b64_path_str = meta.get("b64_path_str")
         if b64_path_str is not None:
             source_physical_fullpath = base64.b64decode(b64_path_str)
-
-        # TODO(#208): Investigate behavior of sync_file when op is None
-        op = meta.get('op', Operation.REGISTER_SYNC)
 
         # PUT_APPEND with existing file
         if op == Operation.PUT_APPEND and exists:
@@ -298,9 +295,6 @@ class s3_scanner(scanner):
         object_name = path_list[1]
 
         MAXIMUM_SINGLE_THREADED_TRANSFER_SIZE = 32 * (1024**2)
-
-        # TODO(#208): Investigate behavior of sync_file when op is None
-        op = meta.get('op', Operation.REGISTER_SYNC)
 
         total_bytes = self.client.stat_object(bucket_name, object_name).size
         # Parallelization is only viable for new files, OR if op=PUT_SYNC for existing data objects since we copy the entire file again

--- a/irods_capability_automated_ingest/sync_irods.py
+++ b/irods_capability_automated_ingest/sync_irods.py
@@ -162,11 +162,7 @@ def register_file(hdlr_mod, logger, session, meta, **options):
     )
 
 
-def upload_file(hdlr_mod, logger, session, meta, **options):
-    scanner = meta.get('scanner')
-    if scanner is None:
-        raise RuntimeError("'scanner' not found in meta. Cannot upload data.")
-
+def upload_file(hdlr_mod, logger, session, meta, scanner, op, **options):
     dest_dataobj_logical_fullpath = meta["target"]
     source_physical_fullpath = meta["path"]
     b64_path_str = meta.get("b64_path_str")
@@ -180,7 +176,7 @@ def upload_file(hdlr_mod, logger, session, meta, **options):
 
     # Use scanner object to upload files
     # exists=False because upload_file is only called from sync_data_from_file if file does not exist yet
-    scanner.upload_file(logger, session, meta, exists=False, **options)
+    scanner.upload_file(logger, session, meta, op, exists=False, **options)
     annotate_metadata_for_special_data_objs(
         meta, session, source_physical_fullpath, dest_dataobj_logical_fullpath
     )
@@ -190,11 +186,7 @@ def no_op(hdlr_mod, logger, session, meta, **options):
     pass
 
 
-def sync_file(hdlr_mod, logger, session, meta, **options):
-    scanner = meta.get('scanner')
-    if scanner is None:
-        raise RuntimeError("'scanner' not found in meta. Cannot sync data.")
-
+def sync_file(hdlr_mod, logger, session, meta, scanner, op, **options):
     dest_dataobj_logical_fullpath = meta["target"]
     source_physical_fullpath = meta["path"]
     b64_path_str = meta.get("b64_path_str")
@@ -209,9 +201,14 @@ def sync_file(hdlr_mod, logger, session, meta, **options):
 
     logger.info("syncing object %s, options = %s" % (dest_dataobj_logical_fullpath, options))
 
+    # TODO: Issue #208
+    # Investigate behavior of sync_file when op is None
+    if op is None:
+        op = Operation.REGISTER_SYNC
+
     # Use scanner object to sync files
     # Ensure exists=True so that upload_file understands that it is a sync_file operation
-    scanner.upload_file(logger, session, meta, exists=True, **options)
+    scanner.upload_file(logger, session, meta, op, exists=True, **options)
 
 
 def update_metadata(hdlr_mod, logger, session, meta, **options):
@@ -420,7 +417,7 @@ def irods_session(handler_module, meta, logger, **options):
     return sess
 
 
-def sync_data_from_file(hdlr_mod, meta, logger, content, **options):
+def sync_data_from_file(hdlr_mod, meta, logger, scanner, content, **options):
     target = meta["target"]
     path = meta["path"]
     init = meta["initial_ingest"]
@@ -478,8 +475,6 @@ def sync_data_from_file(hdlr_mod, meta, logger, content, **options):
 
         put = op in [Operation.PUT, Operation.PUT_SYNC, Operation.PUT_APPEND]
 
-        meta['op'] = op
-
         if not exists:
             meta2 = meta.copy()
             meta2["target"] = dirname(target)
@@ -494,6 +489,8 @@ def sync_data_from_file(hdlr_mod, meta, logger, content, **options):
                     logger,
                     session,
                     meta,
+                    scanner,
+                    op,
                     **options,
                 )
             else:
@@ -529,6 +526,8 @@ def sync_data_from_file(hdlr_mod, meta, logger, content, **options):
                         logger,
                         session,
                         meta,
+                        scanner,
+                        op,
                         **options,
                     )
             else:
@@ -555,15 +554,15 @@ def sync_data_from_file(hdlr_mod, meta, logger, content, **options):
     start_timer()
 
 
-def sync_metadata_from_file(hdlr_mod, meta, logger, **options):
-    sync_data_from_file(hdlr_mod, meta, logger, False, **options)
+def sync_metadata_from_file(hdlr_mod, meta, logger, scanner, **options):
+    sync_data_from_file(hdlr_mod, meta, logger, scanner, False, **options)
 
 
 def sync_dir_meta(hdlr_mod, logger, session, meta, **options):
     pass
 
 
-def sync_data_from_dir(hdlr_mod, meta, logger, content, **options):
+def sync_data_from_dir(hdlr_mod, meta, logger, scanner, content, **options):
     target = meta["target"]
     path = meta["path"]
 
@@ -600,5 +599,5 @@ def sync_data_from_dir(hdlr_mod, meta, logger, content, **options):
     start_timer()
 
 
-def sync_metadata_from_dir(hdlr_mod, meta, logger, **options):
-    sync_data_from_dir(hdlr_mod, meta, logger, False, **options)
+def sync_metadata_from_dir(hdlr_mod, meta, logger, scanner, **options):
+    sync_data_from_dir(hdlr_mod, meta, logger, scanner, False, **options)

--- a/irods_capability_automated_ingest/sync_task.py
+++ b/irods_capability_automated_ingest/sync_task.py
@@ -207,7 +207,7 @@ def restart(meta):
 
 @app.task(bind=True, base=IrodsTask)
 def sync_path(self, meta):
-    scanner_instance = scanner.scanner_factory(meta)
+    syncer = scanner.scanner_factory(meta)
     path = meta["path"]
     config = meta["config"]
     logging_config = config["log"]
@@ -225,7 +225,7 @@ def sync_path(self, meta):
         meta["task"] = "sync_dir"
         chunk = {}
 
-        itr = scanner_instance.instantiate(meta)
+        itr = syncer.instantiate(meta)
 
         if meta["profile"]:
             profile_log = config.get("profile")
@@ -253,7 +253,7 @@ def sync_path(self, meta):
             obj_stats = {}
 
             try:
-                full_path, obj_stats = scanner_instance.itr(meta, obj, obj_stats)
+                full_path, obj_stats = syncer.itr(meta, obj, obj_stats)
             except ContinueException:
                 continue
 
@@ -284,8 +284,8 @@ def sync_path(self, meta):
 
 
 def sync_entry(self, meta, cls, datafunc, metafunc):
-    scanner_instance = meta.get('scanner')
-    if scanner_instance is None:
+    syncer = meta.get('scanner')
+    if syncer is None:
         raise RuntimeError("'scanner' not found in options. Cannot sync data.")
 
     path = meta["path"]
@@ -363,7 +363,7 @@ def sync_entry(self, meta, cls, datafunc, metafunc):
                 else:
                     target2 = target
             else:
-                target2 = scanner_instance.construct_path(meta2, path)
+                target2 = syncer.construct_path(meta2, path)
 
             # If the event handler has a character_map function, it should have returned a
             # structure (either a dict or a list/tuple of key-value tuples) to be used for

--- a/irods_capability_automated_ingest/sync_task.py
+++ b/irods_capability_automated_ingest/sync_task.py
@@ -283,11 +283,7 @@ def sync_path(self, meta):
         raise self.retry(max_retries=max_retries, exc=err, countdown=retry_countdown)
 
 
-def sync_entry(self, meta, cls, datafunc, metafunc):
-    syncer = meta.get('scanner')
-    if syncer is None:
-        raise RuntimeError("'scanner' not found in options. Cannot sync data.")
-
+def sync_entry(self, meta, cls, syncer, datafunc, metafunc):
     path = meta["path"]
     target = meta["target"]
     config = meta["config"]
@@ -383,10 +379,10 @@ def sync_entry(self, meta, cls, datafunc, metafunc):
             meta2["target"] = target2
 
             if sync_time is None or mtime >= sync_time:
-                datafunc(event_handler.get_module(), meta2, logger, True)
+                datafunc(event_handler.get_module(), meta2, logger, syncer, True)
                 logger.info("succeeded", task=meta["task"], path=path)
             else:
-                metafunc(event_handler.get_module(), meta2, logger)
+                metafunc(event_handler.get_module(), meta2, logger, syncer)
                 logger.info("succeeded_metadata_only", task=meta["task"], path=path)
             sync_time_handle.set_value(str(t))
     except Exception as err:
@@ -400,11 +396,12 @@ def sync_entry(self, meta, cls, datafunc, metafunc):
 
 @app.task(bind=True, base=IrodsTask)
 def sync_dir(self, meta):
-    meta['scanner'] = scanner.scanner_factory(meta)
+    syncer = scanner.scanner_factory(meta)
     sync_entry(
         self,
         meta,
         "dir",
+        syncer,
         sync_irods.sync_data_from_dir,
         sync_irods.sync_metadata_from_dir,
     )
@@ -414,8 +411,7 @@ def sync_dir(self, meta):
 def sync_files(self, _meta):
     chunk = _meta["chunk"]
     meta = _meta.copy()
-    meta['scanner'] = scanner.scanner_factory(meta)
-    meta["task"] = "sync_file"
+    syncer = scanner.scanner_factory(meta)
     for path, obj_stats in chunk.items():
         meta["path"] = path
         meta["is_empty_dir"] = obj_stats.get("is_empty_dir")
@@ -424,10 +420,12 @@ def sync_files(self, _meta):
         meta["mtime"] = obj_stats.get("mtime")
         meta["ctime"] = obj_stats.get("ctime")
         meta["size"] = obj_stats.get("size")
+        meta["task"] = "sync_file"
         sync_entry(
             self,
             meta,
             "file",
+            syncer,
             sync_irods.sync_data_from_file,
             sync_irods.sync_metadata_from_file,
         )

--- a/irods_capability_automated_ingest/test/test_irods_sync.py
+++ b/irods_capability_automated_ingest/test/test_irods_sync.py
@@ -23,6 +23,7 @@ from os.path import (
     isfile,
 )
 from irods.session import iRODSSession
+from irods.meta import iRODSMeta
 from irods.models import Collection, DataObject
 from tempfile import NamedTemporaryFile, mkdtemp
 from datetime import datetime
@@ -34,6 +35,7 @@ from irods_capability_automated_ingest.sync_job import sync_job
 from irods.data_object import irods_dirname, irods_basename
 import irods_capability_automated_ingest.examples
 import irods.keywords as kw
+from irods_capability_automated_ingest.utils import Operation
 
 os.environ["CELERY_BROKER_URL"] = "redis://redis:6379/0"
 
@@ -2288,6 +2290,404 @@ class Test_irods_sync_UnicodeEncodeError(
         b"test_register_with_unicode_encode_error_path_" + "\u1000".encode("utf8")[:-1]
     )
     ANNOTATION_REASON = "UnicodeEncodeError"
+
+
+class test_event_handler_methods_for_pre_and_post(unittest.TestCase):
+    def setUp(self):
+        clear_redis()
+        delete_collection_if_exists(PATH_TO_COLLECTION)
+        irmtrash()
+        create_files(NFILES)
+
+    def tearDown(self):
+        delete_files()
+        clear_redis()
+        delete_collection_if_exists(PATH_TO_COLLECTION)
+        irmtrash()
+
+    @staticmethod
+    def create_event_handler_for_operation_from_base_event_handler(base_event_handler_path, operation_name):
+        # Get the contents from the example event handler file.
+        with open(base_event_handler_path, 'r') as eh:
+            original_eh_contents = eh.read()
+
+        # Replace the "OPERATION" with the operation being tested here.
+        eh_contents = re.sub("= Operation\.REGISTER_SYNC", f"= Operation.{operation_name}", original_eh_contents)
+
+        # Write out the contents to a temporary file which will be used as the event handler in this test.
+        temporary_event_handler = NamedTemporaryFile(delete=False)
+        with open(temporary_event_handler.name, 'w') as tf:
+            tf.write(eh_contents)
+
+        return temporary_event_handler
+
+    @staticmethod
+    def run_sync(destination_collection, event_handler_path, job_name, ignore_cache=False):
+        """Launch a pre-specified sync job and await its completion."""
+
+        command = [
+            "python",
+            "-m",
+            IRODS_SYNC_PY,
+            "start",
+            PATH_TO_SOURCE_DIR,
+            destination_collection,
+            "--event_handler",
+            event_handler_path,
+            "--job_name",
+            job_name,
+            "--log_level",
+            "INFO",
+            "--files_per_task",
+            "1",
+        ]
+
+        if ignore_cache:
+            command.append('--ignore_cache')
+
+        proc = subprocess.Popen(command)
+        proc.wait()
+        # ...and then wait for the workers to complete the tasks.
+        workers = start_workers(1)
+        wait_for(workers, job_name)
+
+    def test_data_obj_create(self):
+        """Test that the data_obj_create event handler methods work with all available Operations."""
+
+        function_name = 'data_obj_create'
+        pre_function_name = f'pre_{function_name}'
+        post_function_name = f'post_{function_name}'
+        base_job_name = f'test_{function_name}'
+        eh_name = f'{function_name}_pre_and_post'
+        original_eh_path = event_handler_path(eh_name)
+
+        # Some operations never invoke these pre/post event handler methods, or require special setups. Exclude these.
+        operations_to_skip = [Operation.NO_OP]
+        operations_to_test = [op for op in Operation if op not in operations_to_skip]
+
+        for op in operations_to_test:
+            temporary_event_handler = self.create_event_handler_for_operation_from_base_event_handler(
+                original_eh_path, op.name)
+
+            # The job name helps to identify failures after the sync job completes.
+            job_name = f'{base_job_name}_{op.name}'
+
+            # Each sync job needs to have a unique destination collection in order to differentiate the tests.
+            destination_collection = '/'.join([PATH_TO_COLLECTION, base_job_name, op.name])
+
+            # The event handler is supposed to annotate the following AVUs in the pre method:
+            #     a: name of the event handler "pre" method
+            #     v: full logical path to the data object being created
+            #     a: the name of the operation (e.g. PUT_SYNC)
+            expected_pre_avus = [
+                (pre_function_name, '/'.join([destination_collection, str(i)]), op.name) for i in range(NFILES)]
+
+            # The event handler is supposed to annotate the following AVUs in the post method:
+            #     a: name of the event handler "post" method
+            #     v: full logical path to the data object being created
+            #     a: the name of the operation (e.g. PUT_SYNC)
+            expected_post_avus = [
+                (post_function_name, '/'.join([destination_collection, str(i)]), op.name) for i in range(NFILES)]
+
+            expected_avus = expected_pre_avus + expected_post_avus
+
+            with self.subTest(f'operation: {op.name}'):
+                with iRODSSession(**get_kwargs()) as session:
+                    try:
+                        # Ensure that the destination collection does not exist so that we can create it fresh.
+                        if session.collections.exists(destination_collection):
+                            session.collections.remove(destination_collection, force=True)
+                        session.collections.create(destination_collection)
+
+                        # Run the sync job and ensure that no failures occurred.
+                        self.run_sync(destination_collection, temporary_event_handler.name, job_name)
+                        self.assertEqual(sync_job(job_name, get_redis()).failures_handle().get_value(), None)
+
+                        metadata_items = session.collections.get(destination_collection).metadata.items()
+                        self.assertNotEqual(len(metadata_items), 0)
+
+                        # Collect the AVUs from the expected set which actually got annotated.
+                        expected_avus_which_were_annotated = []
+                        for a, v, u in metadata_items:
+                            avu = (a, v, u)
+                            if avu in expected_avus:
+                                expected_avus_which_were_annotated.append(avu)
+
+                        # Assert that ALL of the expected AVUs were found to be annotated. We just collected all of
+                        # the AVUs which were annotated and are in the set of expected AVUs, so if the sets are equal,
+                        # that means all of the AVUs we expected were annotated.
+                        self.assertEqual(sorted(expected_avus_which_were_annotated), sorted(expected_avus))
+
+                    finally:
+                        if session.collections.exists(destination_collection):
+                            session.collections.remove(destination_collection, force=True)
+
+    def test_data_obj_modify(self):
+        """Test that the data_obj_modify event handler methods work with all available Operations."""
+
+        function_name = 'data_obj_modify'
+        pre_function_name = f'pre_{function_name}'
+        post_function_name = f'post_{function_name}'
+        base_job_name = f'test_{function_name}'
+        eh_name = f'{function_name}_pre_and_post'
+        original_eh_path = event_handler_path(eh_name)
+
+        # Some operations never invoke these pre/post event handler methods, or require special setups. Exclude these.
+        operations_to_skip = [Operation.NO_OP, Operation.PUT, Operation.REGISTER_AS_REPLICA_SYNC]
+        operations_to_test = [op for op in Operation if op not in operations_to_skip]
+
+        for op in operations_to_test:
+            temporary_event_handler = self.create_event_handler_for_operation_from_base_event_handler(
+                original_eh_path, op.name)
+
+            # The job name helps to identify failures after the sync job completes.
+            job_name = f'{base_job_name}_{op.name}'
+            update_job_name = f'{base_job_name}_{op.name}_update'
+
+            # Each sync job needs to have a unique destination collection in order to differentiate the tests.
+            destination_collection = '/'.join([PATH_TO_COLLECTION, base_job_name, op.name])
+
+            # The event handler is supposed to annotate the following AVUs in the pre method:
+            #     a: name of the event handler "pre" method
+            #     v: full logical path to the data object being modified
+            #     a: the name of the operation (e.g. PUT_SYNC)
+            expected_pre_avus = [
+                (pre_function_name, '/'.join([destination_collection, str(i)]), op.name) for i in range(NFILES)]
+
+            # The event handler is supposed to annotate the following AVUs in the post method:
+            #     a: name of the event handler "post" method
+            #     v: full logical path to the data object being modified
+            #     a: the name of the operation (e.g. PUT_SYNC)
+            expected_post_avus = [
+                (post_function_name, '/'.join([destination_collection, str(i)]), op.name) for i in range(NFILES)]
+
+            expected_avus = expected_pre_avus + expected_post_avus
+
+            with self.subTest(f'operation: {op.name}'):
+                with iRODSSession(**get_kwargs()) as session:
+                    try:
+                        # Ensure that the destination collection does not exist so that we can create it fresh.
+                        if session.collections.exists(destination_collection):
+                            session.collections.remove(destination_collection, force=True)
+                        session.collections.create(destination_collection)
+
+                        # Run the sync job and ensure that no failures occurred.
+                        self.run_sync(destination_collection, temporary_event_handler.name, job_name)
+                        self.assertEqual(sync_job(job_name, get_redis()).failures_handle().get_value(), None)
+
+                        # Ensure that none of the expected AVUs have been annotated yet.
+                        for a, v, u in session.collections.get(destination_collection).metadata.items():
+                            self.assertNotIn((a, v, u), expected_avus)
+
+                        # Modify each file so that the second scan updates the data objects.
+                        for i in range(NFILES):
+                            filepath = os.path.join(PATH_TO_SOURCE_DIR, str(i))
+                            with open(filepath, 'a') as f:
+                                f.write(f'updating file {i}')
+
+                        # Run the sync job again - ignoring the cache - and ensure that no failures occurred. This
+                        # time, the data objects should just be updated.
+                        self.run_sync(destination_collection, temporary_event_handler.name, update_job_name, ignore_cache=True)
+                        self.assertEqual(sync_job(update_job_name, get_redis()).failures_handle().get_value(), None)
+
+                        metadata_items = session.collections.get(destination_collection).metadata.items()
+                        self.assertNotEqual(len(metadata_items), 0)
+
+                        # Collect the AVUs from the expected set which actually got annotated.
+                        expected_avus_which_were_annotated = []
+                        for a, v, u in metadata_items:
+                            avu = (a, v, u)
+                            if avu in expected_avus:
+                                expected_avus_which_were_annotated.append(avu)
+
+                        # Assert that ALL of the expected AVUs were found to be annotated. We just collected all of
+                        # the AVUs which were annotated and are in the set of expected AVUs, so if the sets are equal,
+                        # that means all of the AVUs we expected were annotated.
+                        self.assertEqual(sorted(expected_avus_which_were_annotated), sorted(expected_avus))
+
+                    finally:
+                        if session.collections.exists(destination_collection):
+                            session.collections.remove(destination_collection, force=True)
+
+    def test_coll_create(self):
+        """Test that the coll_create event handler methods work with all available Operations."""
+
+        function_name = 'coll_create'
+        pre_function_name = f'pre_{function_name}'
+        post_function_name = f'post_{function_name}'
+        base_job_name = f'test_{function_name}'
+        eh_name = f'{function_name}_pre_and_post'
+        original_eh_path = event_handler_path(eh_name)
+
+        # Some operations never invoke these pre/post event handler methods, or require special setups. Exclude these.
+        operations_to_skip = [Operation.NO_OP, Operation.REGISTER_AS_REPLICA_SYNC]
+        operations_to_test = [op for op in Operation if op not in operations_to_skip]
+
+        for op in operations_to_test:
+            temporary_event_handler = self.create_event_handler_for_operation_from_base_event_handler(
+                original_eh_path, op.name)
+
+            # The job name helps to identify failures after the sync job completes.
+            job_name = f'{base_job_name}_{op.name}'
+
+            # Each sync job needs to have a unique destination collection in order to differentiate the tests.
+            destination_collection = '/'.join([PATH_TO_COLLECTION, base_job_name, op.name])
+
+            # Because we are testing the pre and post methods for coll_create, the collection will not exist in the
+            # pre event handler method, so we will annotate metadata to the parent collection.
+            # This is an iRODS logical path but this may be running on Windows, hence not using os.path.dirname.
+            parent_of_destination_collection = '/'.join(destination_collection.split('/')[:-1])
+
+            # The event handler is supposed to annotate the following AVUs in the pre method:
+            #     a: name of the event handler "pre" method
+            #     v: full logical path to the collection being created
+            #     a: the name of the operation (e.g. PUT_SYNC)
+            # There will only be one pre method invoked for the creation of the collection.
+            expected_pre_avus = [(pre_function_name, destination_collection, op.name)]
+
+            # The event handler is supposed to annotate the following AVUs in the post method:
+            #     a: name of the event handler "post" method
+            #     v: full logical path to the collection being created
+            #     a: the name of the operation (e.g. PUT_SYNC)
+            # There will only be one post method invoked for the creation of the collection.
+            expected_post_avus = [(post_function_name, destination_collection, op.name)]
+
+            expected_avus = expected_pre_avus + expected_post_avus
+
+            with self.subTest(f'operation: {op.name}'):
+                with iRODSSession(**get_kwargs()) as session:
+                    try:
+                        # Ensure that the destination collection does not exist so that it is created by the sync job.
+                        if session.collections.exists(parent_of_destination_collection):
+                            session.collections.remove(parent_of_destination_collection, force=True)
+
+                        # Create the parent of the destination collection so that there is something onto which metadata
+                        # can be annotated for this test.
+                        session.collections.create(parent_of_destination_collection)
+
+                        # Run the sync job and ensure that no failures occurred.
+                        self.run_sync(destination_collection, temporary_event_handler.name, job_name)
+                        self.assertEqual(sync_job(job_name, get_redis()).failures_handle().get_value(), None)
+
+                        # Because the collection is new at the start, we can assert the exact number of metadata items
+                        # we expect to be annotated to this collection.
+                        metadata_items = session.collections.get(parent_of_destination_collection).metadata.items()
+                        self.assertEqual(len(metadata_items), 2)
+
+                        # Collect the AVUs from the expected set which actually got annotated.
+                        expected_avus_which_were_annotated = []
+                        for a, v, u in metadata_items:
+                            avu = (a, v, u)
+                            if avu in expected_avus:
+                                expected_avus_which_were_annotated.append(avu)
+
+                        # Assert that ALL of the expected AVUs were found to be annotated. We just collected all of
+                        # the AVUs which were annotated and are in the set of expected AVUs, so if the sets are equal,
+                        # that means all of the AVUs we expected were annotated.
+                        self.assertEqual(sorted(expected_avus_which_were_annotated), sorted(expected_avus))
+
+                    finally:
+                        # Remove all metadata items from the parent collection for idempotency.
+                        if session.collections.exists(parent_of_destination_collection):
+                            session.collections.remove(parent_of_destination_collection, force=True)
+
+    def test_coll_modify(self):
+        """Test that the coll_modify event handler methods work with all available Operations."""
+
+        function_name = 'coll_modify'
+        pre_function_name = f'pre_{function_name}'
+        post_function_name = f'post_{function_name}'
+        base_job_name = f'test_{function_name}'
+        eh_name = f'{function_name}_pre_and_post'
+        original_eh_path = event_handler_path(eh_name)
+
+        # Some operations never invoke these pre/post event handler methods, or require special setups. Exclude these.
+        operations_to_skip = [Operation.NO_OP, Operation.PUT, Operation.REGISTER_AS_REPLICA_SYNC]
+        operations_to_test = [op for op in Operation if op not in operations_to_skip]
+
+        for op in operations_to_test:
+            temporary_event_handler = self.create_event_handler_for_operation_from_base_event_handler(
+                original_eh_path, op.name)
+
+            # The job name helps to identify failures after the sync job completes.
+            job_name = f'{base_job_name}_{op.name}'
+            update_job_name = f'{base_job_name}_{op.name}_update'
+
+            # Each sync job needs to have a unique destination collection in order to differentiate the tests.
+            destination_collection = '/'.join([PATH_TO_COLLECTION, base_job_name, op.name])
+
+            # The event handler is supposed to annotate the following AVUs in the pre method:
+            #     a: name of the event handler "pre" method
+            #     v: the job name (coll_modify is not triggered for each data object)
+            #     a: the name of the operation (e.g. PUT_SYNC)
+            expected_pre_avus = [
+                (pre_function_name, job_name, op.name),
+                (pre_function_name, update_job_name, op.name)
+            ]
+
+            # The event handler is supposed to annotate the following AVUs in the post method:
+            #     a: name of the event handler "post" method
+            #     v: the job name (coll_modify is not triggered for each data object)
+            #     a: the name of the operation (e.g. PUT_SYNC)
+            expected_post_avus = [
+                (post_function_name, job_name, op.name),
+                (post_function_name, update_job_name, op.name)
+            ]
+
+            expected_avus = expected_pre_avus + expected_post_avus
+
+            with self.subTest(f'operation: {op.name}'):
+                with iRODSSession(**get_kwargs()) as session:
+                    try:
+                        # Ensure that the destination collection does not exist so that we can create it fresh.
+                        if session.collections.exists(destination_collection):
+                            session.collections.remove(destination_collection, force=True)
+                        session.collections.create(destination_collection)
+
+                        # Run the sync job and ensure that no failures occurred.
+                        self.run_sync(destination_collection, temporary_event_handler.name, job_name)
+                        self.assertEqual(sync_job(job_name, get_redis()).failures_handle().get_value(), None)
+
+                        # Ensure that no metadata items have been annotated because the collection was not modified.
+                        #self.assertEqual(len(session.collections.get(destination_collection).metadata.items()), 0)
+
+                        # TODO(#240): coll_modify is called after coll_create or after each chunk of files is created
+                        # and I would not have expected this to happen until something was actually updated.
+                        self.assertEqual(len(session.collections.get(destination_collection).metadata.items()), 2)
+
+                        # Modify each file so that the second scan updates the data objects and consequently the
+                        # collection, as well.
+                        for i in range(NFILES):
+                            filepath = os.path.join(PATH_TO_SOURCE_DIR, str(i))
+                            with open(filepath, 'a') as f:
+                                f.write(f'updating file {i}')
+
+                        # Run the sync job again - ignoring the cache - and ensure that no failures occurred. This
+                        # time, the data objects should just be updated.
+                        self.run_sync(
+                            destination_collection, temporary_event_handler.name, update_job_name, ignore_cache=True)
+                        self.assertEqual(sync_job(update_job_name, get_redis()).failures_handle().get_value(), None)
+
+                        # Because the collection is new at the start, we can assert the exact number of metadata items
+                        # we expect to be annotated to this collection.
+                        metadata_items = session.collections.get(destination_collection).metadata.items()
+                        self.assertEqual(len(metadata_items), len(expected_avus))
+
+                        # Collect the AVUs from the expected set which actually got annotated.
+                        expected_avus_which_were_annotated = []
+                        for a, v, u in metadata_items:
+                            avu = (a, v, u)
+                            if avu in expected_avus:
+                                expected_avus_which_were_annotated.append(avu)
+
+                        # Assert that ALL of the expected AVUs were found to be annotated. We just collected all of
+                        # the AVUs which were annotated and are in the set of expected AVUs, so if the sets are equal,
+                        # that means all of the AVUs we expected were annotated.
+                        self.assertEqual(sorted(expected_avus_which_were_annotated), sorted(expected_avus))
+
+                    finally:
+                        if session.collections.exists(destination_collection):
+                            session.collections.remove(destination_collection, force=True)
 
 
 def main():


### PR DESCRIPTION
Addresses #219 (for real)

This partially reverts the work done in https://github.com/irods/irods_capability_automated_ingest/pull/236.

This change primarily adds tests for almost all relevant operations for all pre/post event handler methods that we currently support. This is meant to act as a minimal baseline to ensure that the pre/post methods are executing properly.

Case in point: Possible bug was discovered while writing these tests and has been created here: #240.

All new tests pass. Running full suite now.