### PR TITLE
Fix PUT operation documentation and give node name to demo Celery workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ This operation creates only new data objects by writing the data to the vault of
 
 If the target logical path does not exist at the time of sync, this operation writes the data to the vault of the target resource and registers it in the catalog as a new data object.
 
-If the target logical path exists and has a replica on the target resource, this operation emits an error. Use `PUT_SYNC` or `PUT_APPEND` to sync data to existing replicas.
+If the target logical path exists and has a replica on the target resource, no data is synced. `PUT` will only create new data objects which do not already exist. Use `PUT_SYNC` or `PUT_APPEND` to sync data to existing replicas.
 
 If the target logical path exists but does not have a replica on the target resource, this operation emits an error. The "put"-type operations are not allowed to create new replicas of existing data objects.
 

--- a/docker/demo/compose.yaml
+++ b/docker/demo/compose.yaml
@@ -45,7 +45,7 @@ services:
                 condition: service_started
             irods-catalog-provider:
                 condition: service_healthy
-        command: ["-c", "2", "--loglevel", "INFO"] # Configure Celery options here. Note: Only takes effect at container creation.
+        command: ["-c", "2", "--loglevel", "INFO", "-n", "ingest-demo"] # Configure Celery options here. Note: Only takes effect at container creation.
 
     minio:
         image: minio/minio:RELEASE.2024-06-28T09-06-49Z

--- a/irods_capability_automated_ingest/irods/filesystem.py
+++ b/irods_capability_automated_ingest/irods/filesystem.py
@@ -362,8 +362,12 @@ def sync_data_from_file(hdlr_mod, meta, logger, content, **options):
             )
         elif content:
             if put:
-                sync = op in [Operation.PUT_SYNC, Operation.PUT_APPEND]
-                if sync:
+                if Operation.PUT == op:
+                    logger.debug(
+                        f"PUT operation will ignore existing data object [{meta['target']}]"
+                    )
+                else:
+                    # PUT_SYNC and PUT_APPEND sync data on existing data objects.
                     event_handler.call(
                         "on_data_obj_modify",
                         logger,

--- a/irods_capability_automated_ingest/irods/s3_bucket.py
+++ b/irods_capability_automated_ingest/irods/s3_bucket.py
@@ -579,8 +579,12 @@ def sync_data_from_file(hdlr_mod, meta, logger, content, **options):
             )
         elif content:
             if put:
-                sync = op in [Operation.PUT_SYNC, Operation.PUT_APPEND]
-                if sync:
+                if Operation.PUT == op:
+                    logger.debug(
+                        f"PUT operation will ignore existing data object [{meta['target']}]"
+                    )
+                else:
+                    # PUT_SYNC and PUT_APPEND sync data on existing data objects.
                     event_handler.call(
                         "on_data_obj_modify",
                         logger,


### PR DESCRIPTION
Addresses #289

The node name thing is to prevent a warning message that appears if multiple Celery worker nodes are running in the same host.