### PR TITLE
`irods_sync` script fixes and enhancements (plus one other bug fix)

### DIFF
--- a/irods_capability_automated_ingest/redis_key.py
+++ b/irods_capability_automated_ingest/redis_key.py
@@ -95,11 +95,9 @@ class list_redis_key_handle(redis_key_handle):
         return self.retry(self.redis_handle.llen, self.get_key())
 
 
-# TODO: python metaclasses - see PRC
-# sync_time_key - float with last time particular path was sync'd
-class sync_time_key_handle(redis_key_handle):
-    def __init__(self, redis_handle, path):
-        super().__init__(redis_handle, "sync_time", path)
+class float_redis_key_handle(redis_key_handle):
+    def __init__(self, redis_handle, key_category, identifier, delimiter=":/"):
+        super().__init__(redis_handle, key_category, identifier, delimiter)
 
     def get_value(self):
         val = super().get_value()
@@ -108,14 +106,24 @@ class sync_time_key_handle(redis_key_handle):
         return float(val)
 
 
-# cleanup_key - JSON object with list of event_handlers that need to be cleaned up
+# TODO(#292): python metaclasses - see PRC
+class sync_time_key_handle(float_redis_key_handle):
+    """Float indicating the last time path was synced."""
+
+    def __init__(self, redis_handle, path):
+        super().__init__(redis_handle, "sync_time", path)
+
+
 class cleanup_key_handle(json_redis_key_handle):
+    """JSON object with list of event_handlers that need to be cleaned up."""
+
     def __init__(self, redis_handle, job_name):
         super().__init__(redis_handle, "cleanup", job_name)
 
 
-# stop_key - value:empty string (job_name needs to be stopped)
 class stop_key_handle(redis_key_handle):
+    """Empty string indicating that the job job_name_to_stop is being stopped."""
+
     def __init__(self, redis_handle, job_name_to_stop):
         super().__init__(redis_handle, "stop", job_name_to_stop)
 
@@ -126,32 +134,37 @@ class stop_key_handle(redis_key_handle):
         return str(val)
 
 
-# tasks_key - value:int task count for job name
 class tasks_key_handle(incremental_redis_key_handle):
+    """Integer indicating the task count for job_name."""
+
     def __init__(self, redis_handle, job_name):
         super().__init__(redis_handle, "tasks", job_name)
 
 
-# count_key - value:list of task_ids for job name
 class count_key_handle(list_redis_key_handle):
+    """List of task IDs associated with job_name."""
+
     def __init__(self, redis_handle, job_name):
         super().__init__(redis_handle, "count", job_name)
 
 
-# dequeue_key - value:list of tasks for a particular job_name
 # TODO: What is the difference between this list and the set of stop_keys?
 class dequeue_key_handle(list_redis_key_handle):
+    """List of tasks for a particular job_name."""
+
     def __init__(self, redis_handle, job_name):
         super().__init__(redis_handle, "dequeue", job_name)
 
 
-# failures_key - value:int with count of failed tasks
 class failures_key_handle(incremental_redis_key_handle):
+    """Integer indicating the count of failed tasks for job_name."""
+
     def __init__(self, redis_handle, job_name):
         super().__init__(redis_handle, "failures", job_name)
 
 
-# retries_key - value:int number of retries attempted for job_name
 class retries_key_handle(incremental_redis_key_handle):
+    """Integer indicating the count of tasks which were retried for job_name."""
+
     def __init__(self, redis_handle, job_name):
         super().__init__(redis_handle, "retries", job_name)

--- a/irods_capability_automated_ingest/redis_key.py
+++ b/irods_capability_automated_ingest/redis_key.py
@@ -168,3 +168,10 @@ class retries_key_handle(incremental_redis_key_handle):
 
     def __init__(self, redis_handle, job_name):
         super().__init__(redis_handle, "retries", job_name)
+
+
+class stopped_jobs_key_handle(json_redis_key_handle):
+    """JSON object with list of sync_job dicts."""
+
+    def __init__(self, redis_handle):
+        super().__init__(redis_handle, "irods_ingest_stopped_jobs", "")

--- a/irods_capability_automated_ingest/sync_job.py
+++ b/irods_capability_automated_ingest/sync_job.py
@@ -69,6 +69,7 @@ class sync_job(object):
         self.tasks_handle().reset()
         self.failures_handle().reset()
         self.retries_handle().reset()
+        self.start_time_handle().reset()
 
     def interrupt(self, cli=True, terminate=True):
         self.stop_handle().set_value("")
@@ -90,3 +91,8 @@ class sync_job(object):
         # stop restart job
         app.control.revoke(self.job_name)
         self.stop_handle().reset()
+
+    def start_time_handle(self):
+        return redis_key.float_redis_key_handle(
+            self.r, "irods_ingest_job_start_time", self.job_name
+        )

--- a/irods_capability_automated_ingest/sync_logging.py
+++ b/irods_capability_automated_ingest/sync_logging.py
@@ -15,7 +15,7 @@ def timestamper(logger, log_method, event_dict):
     event_dict["@timestamp"] = (
         datetime.datetime.now()
         .replace(tzinfo=datetime.timezone(offset=utc_offset))
-        .isoformat()
+        .isoformat(timespec="milliseconds")
     )
     return event_dict
 

--- a/irods_capability_automated_ingest/tasks/filesystem_tasks.py
+++ b/irods_capability_automated_ingest/tasks/filesystem_tasks.py
@@ -107,7 +107,7 @@ def filesystem_main_task(meta):
     interval = meta["interval"]
     meta["root_target_collection"] = meta["target"]
     if interval is not None:
-        restart.s(meta).apply_async(
+        filesystem_main_task.s(meta).apply_async(
             task_id=job_name, queue=restart_queue, countdown=interval
         )
 

--- a/irods_capability_automated_ingest/tasks/filesystem_tasks.py
+++ b/irods_capability_automated_ingest/tasks/filesystem_tasks.py
@@ -24,6 +24,7 @@ import os
 import re
 import redis_lock
 import stat
+import time
 import traceback
 
 
@@ -129,6 +130,7 @@ def filesystem_main_task(meta):
             )
 
             job.reset()
+            job.start_time_handle().set_value(time.time())
             meta = meta.copy()
             meta["task"] = "filesystem_sync_path"
             meta["queue_name"] = meta["path_queue"]

--- a/irods_capability_automated_ingest/tasks/s3_bucket_tasks.py
+++ b/irods_capability_automated_ingest/tasks/s3_bucket_tasks.py
@@ -18,6 +18,7 @@ import os
 import re
 import redis_lock
 import stat
+import time
 import traceback
 
 
@@ -50,6 +51,7 @@ def s3_bucket_main_task(meta):
             )
 
             job.reset()
+            job.start_time_handle().set_value(time.time())
             meta = meta.copy()
             meta["task"] = "s3_bucket_sync_path"
             meta["queue_name"] = meta["path_queue"]

--- a/irods_capability_automated_ingest/tasks/s3_bucket_tasks.py
+++ b/irods_capability_automated_ingest/tasks/s3_bucket_tasks.py
@@ -28,7 +28,7 @@ def s3_bucket_main_task(meta):
     restart_queue = meta["restart_queue"]
     interval = meta["interval"]
     if interval is not None:
-        restart.s(meta).apply_async(
+        s3_bucket_main_task.s(meta).apply_async(
             task_id=job_name, queue=restart_queue, countdown=interval
         )
 

--- a/irods_capability_automated_ingest/test/test_irods_sync.py
+++ b/irods_capability_automated_ingest/test/test_irods_sync.py
@@ -1931,7 +1931,7 @@ class test_exclude_options(automated_ingest_test_context, unittest.TestCase):
         ]
         try:
             # Create the test file and modify permissions such that it is unreadable.
-            with open(unreadable_file_path, "w") as f: 
+            with open(unreadable_file_path, "w") as f:
                 f.write("this will not be read!")
             os.chmod(unreadable_file_path, 0o000)
             # Run the sync job...


### PR DESCRIPTION
Addresses #91 
Addresses #92 
Addresses #93 
Addresses #210 
Addresses #293

I'm contemplating adding tests for these subcommands, but it seems a little tricky (hence, draft PR) and there are no existing tests for any of the subcommands other than `start`. Existing tests are passing.

Also, the two commits referencing #210 (only) can be squashed into one if we like the solution of maintaining a list of stopped jobs. Otherwise, we can drop the second commit because the first one addresses the issue (albeit, not as well, IMO).