### PR TITLE
[#266] Bump Celery minimum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,10 @@ setup(
         "python-irodsclient<3.0.0",
         "python-redis-lock>=3.2.0",
         "redis>=3.4.1, <5.0.0",
-        "celery[redis]>=5.2.2, <5.3.0",
+        "celery[redis]<6.0.0",
         "scandir",
         "structlog>=18.1.0",
         "progressbar2",
-        "billiard>=3.6.4.0, <4.0",
     ],
     setup_requires=["setuptools>=38.6.0"],
     entry_points={


### PR DESCRIPTION
Addresses #266

This is required in order for ingest to work with python 3.12. Additionally, this removes the specific versioning requirements around the `billiard` package. This is a dependency of Celery, so we can just let `pip` figure out what version to install.

I have confirmed that tests are passing on python 3.8, 3.12, and 3.13 with this change.